### PR TITLE
fix: make the default pipeline assemble, link, and boot (#5, #7, #39)

### DIFF
--- a/exporter/exporter_ca65.py
+++ b/exporter/exporter_ca65.py
@@ -540,6 +540,8 @@ class CA65Exporter(BaseExporter):
                 '',
                 'init_music:',
                 '    ; Initialize APU for music playback',
+                '    lda #$40',
+                '    sta $4017  ; Frame counter mode 1, disable frame IRQ (NES_APU_REFERENCE 3.2)',
                 '    lda #$0F',
                 '    sta $4015  ; Enable all channels',
                 '    lda #$00',
@@ -671,21 +673,14 @@ class CA65Exporter(BaseExporter):
         lines.append('; ---------------------------------------------------------------------------')
         lines.append('.segment "CODE_8000"')
         lines.append('')
-        lines.append('; DPCM Lookup Tables')
-        lines.append('dpcm_bank_table:')
-        lines.append('    .byte $00')
-        lines.append('dpcm_pitch_table:')
-        lines.append('    .byte $0F')
-        lines.append('dpcm_addr_table:')
-        lines.append('    .byte $00')
-        lines.append('dpcm_len_table:')
-        lines.append('    .byte $00')
-        lines.append('')
+        # The DPCM lookup tables (dpcm_bank_table/pitch/addr/len) are owned by the
+        # DPCM packer when real samples exist, and stubbed by the project builder
+        # otherwise. Defining them here too would be a duplicate-symbol error once
+        # the packer appends the real tables to music.asm.
         
         # Export symbols needed by the audio engine
         lines.append('.export pulse1_sequence, pulse2_sequence, triangle_sequence, noise_sequence, dpcm_sequence')
         lines.append('.export ntsc_period_low, ntsc_period_high')
-        lines.append('.export dpcm_bank_table, dpcm_pitch_table, dpcm_addr_table, dpcm_len_table')
         lines.append('.export instrument_table')
         lines.append('')
         

--- a/mappers/mmc3.py
+++ b/mappers/mmc3.py
@@ -61,12 +61,20 @@ class MMC3Mapper(BaseMapper):
             '    HEADER:   load = HDR, type = ro;',
             '    ZEROPAGE: load = ZP,  type = zp;',
             '    BSS:      load = RAM, type = bss, define = yes;',
-            '    OAM:      load = OAM, type = bss, align = $100;'
+            '    OAM:      load = OAM, type = bss, align = $100;',
+            # Lookup/macro/instrument tables are read with absolute addressing by
+            # the engine, so they must live in an always-mapped bank. In PRG mode 1
+            # the $8000-$9FFF window is the fixed second-to-last bank.
+            '    CODE_8000: load = PRG_80, type = ro, optional = yes;'
         ])
 
-        # Generate DPCM segments for Banks 0-59
+        # Generate DPCM + sequence-bank segments for Banks 0-59.
+        # BANK_NN holds the per-channel sequence bytecode; fetch_sequence_byte
+        # swaps the bank into the $A000 (R7) window and translates the pointer,
+        # so a BANK_NN linked into PRG_BANK_NN (PRG-pool bank N) resolves correctly.
         for i in range(60):
             lines.append(f'    DPCM_{i:02d}:   load = PRG_BANK_{i:02d}, type = ro, optional = yes;')
+            lines.append(f'    BANK_{i:02d}:   load = PRG_BANK_{i:02d}, type = ro, optional = yes;')
 
         lines.extend([
             '    CODE:     load = PRG_FIX, type = ro;',

--- a/nes/audio_engine.asm
+++ b/nes/audio_engine.asm
@@ -118,7 +118,17 @@ audio_init:
     
     ; Initialize DMC output level to 0 to prevent muffling Triangle/Noise
     sta $4011
-    
+
+    ; Initialize the APU so the NMI-driven engine owns the channels.
+    ; $4017 = $40: frame counter mode 1, disable frame IRQ so it cannot
+    ; clock length/envelope units against us (docs/NES_APU_REFERENCE.md §3.2).
+    lda #$40
+    sta $4017
+    ; $4015 = $0F: enable Pulse1/Pulse2/Triangle/Noise. DMC (bit 4) is enabled
+    ; on demand by the sample playback handlers (docs/NES_APU_REFERENCE.md §3.1).
+    lda #$0F
+    sta $4015
+
     ; Clear macro steps
     ldx #4
 @clear_macros:
@@ -173,12 +183,18 @@ audio_update:
     cmp #$FF
     bne :+
     jmp @end_of_stream ; Halt sequence if end marker $FF is hit
-:   
+:
+    ; Dispatch by byte range. @is_note/@is_length live far past the command
+    ; handlers below, so branch to a local trampoline and jmp to the far target
+    ; (a direct bcc would exceed the 6502 +/-127 relative-branch range).
     cmp #$60
-    bcc @is_note
+    bcs @chk_length
+    jmp @is_note      ; < $60 -> note
+@chk_length:
     cmp #$80
-    bcc @is_length
-    
+    bcs @is_command   ; >= $80 -> command (falls through below)
+    jmp @is_length    ; $60-$7F -> length
+
 @is_command:
     ; Handle commands ($80 - $FE)
     cmp #$FE

--- a/nes/project_builder.py
+++ b/nes/project_builder.py
@@ -429,6 +429,22 @@ process_channel_macros:
     rts
 """
 
+        # Guarantee the DPCM lookup tables the audio engine imports resolve exactly
+        # once. The DPCM packer emits the real tables (appended to music.asm before
+        # this runs) when samples exist; otherwise nothing has defined them, so emit
+        # harmless single-byte stubs. The packer never exports the symbols, so do it
+        # here regardless of which side defined them.
+        music_content += "\n.export dpcm_bank_table, dpcm_pitch_table, dpcm_addr_table, dpcm_len_table\n"
+        if "dpcm_bank_table:" not in music_content:
+            music_content += (
+                '\n.segment "RODATA"\n'
+                "; Stub DPCM lookup tables (no samples packed)\n"
+                "dpcm_bank_table:\n    .byte $00\n"
+                "dpcm_pitch_table:\n    .byte $00\n"
+                "dpcm_addr_table:\n    .byte $00\n"
+                "dpcm_len_table:\n    .byte $00\n"
+            )
+
         # Write music.asm
         (self.project_path / "music.asm").write_text(music_content)
         
@@ -443,8 +459,11 @@ process_channel_macros:
         # Generate main.asm
         main_content = self._generate_main_asm()
         
-        # Add mapper-specific bank switching code and export it
-        main_content += "\n.global switch_dpcm_bank\n"
+        # Add mapper-specific bank switching code and export it.
+        # The main.asm template ends inside the VECTORS segment, so switch back
+        # to CODE first — otherwise this routine is assembled into VECTORS and
+        # overflows the 6-byte reset/NMI/IRQ area.
+        main_content += '\n.segment "CODE"\n.global switch_dpcm_bank\n'
         main_content += self.mapper.generate_bank_switch_code(0)
         
         # Add safe joypad reading logic for DMC DMA conflicts

--- a/tests/test_ca65_export.py
+++ b/tests/test_ca65_export.py
@@ -261,6 +261,26 @@ class TestCA65CompilationIntegration(unittest.TestCase):
         success, output = self.compile_and_link(str(self.project_path))
         self.assertTrue(success, f"Compilation failed:\n{output}")
 
+    def test_apu_initialized_in_boot_path(self):
+        """The generated project must initialize the APU frame counter ($4017)
+        and channel-enable register ($4015) before playback, otherwise the
+        hardware frame sequencer fights the NMI-driven engine (issue #7).
+        """
+        self.project_path.mkdir(parents=True, exist_ok=True)
+        music_asm = self.project_path / "music.asm"
+        self.exporter.export_tables_with_patterns(
+            self.test_frames, self.test_patterns, self.test_references,
+            music_asm, standalone=False,
+        )
+        self.patch_music_asm(music_asm)
+        self.builder.prepare_project(str(music_asm))
+
+        # The patterns path boots via audio_engine.asm's audio_init.
+        engine = (self.project_path / "audio_engine.asm").read_text()
+        init = engine.split("audio_init:", 1)[1].split("audio_update:", 1)[0]
+        self.assertIn("$4017", init, "audio_init must write the frame counter ($4017)")
+        self.assertIn("$4015", init, "audio_init must enable channels ($4015)")
+
     def test_empty_project_compilation(self):
         """Test that a project with no music data still compiles"""
         # Create project directory first


### PR DESCRIPTION
The default (patterns-on) MIDI->NES pipeline could not produce a ROM. Three root causes, all on the path from generated music data to a bootable .nes:

#39 audio_engine.asm sequence dispatch used `bcc @is_note` / `bcc @is_length` to targets >127 bytes away, past the command handlers — a 6502 branch-range error, so every generated project failed to assemble. Dispatch via local trampolines that `jmp` to the far targets.

#5 export_tables_with_patterns emits `.segment "CODE_8000"` (absolute-addressed lookup/macro/instrument tables) and `.segment "BANK_NN"` (sequence bytecode), neither defined in the MMC3 linker config, so `ld65` aborted. Map CODE_8000 to the fixed $8000 bank (PRG mode 1) and BANK_NN to the PRG bank pool that fetch_sequence_byte swaps through the $A000/R7 window. Also fix main.asm generation: the bank-switch routine was appended inside the VECTORS segment and overflowed the 6-byte reset/NMI/IRQ area — switch back to CODE first.

#7 audio_init wrote only $4011; the APU frame counter ($4017) and channel enables ($4015) were never initialized, leaving the hardware frame sequencer to fight the NMI-driven engine. Initialize $4017=$40 (mode 1, IRQ off) and $4015=$0F in both the macro engine's audio_init and the no-patterns init_music.

Single-owner DPCM tables: the exporter stub and the DPCM packer both defined dpcm_bank_table et al., a duplicate-symbol error in the real pipeline. The exporter no longer defines/exports them; prepare_project now guarantees they exist (packer's real tables, or single-byte stubs) and exports them once.

Default pipeline now builds end-to-end with valid vectors (NMI/RESET/IRQ in the fixed bank). 6 of 7 CA65 compile-integration tests pass plus a new APU-init regression test; the 7th (empty/--no-patterns direct path) fails for an unrelated pre-existing reason tracked in #50.