### PR TITLE
fix: clean up .nes.backup on success and document song-bank scope (#2…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ python main.py detect-patterns frames.json patterns.json  # Pattern detection
 python main.py export frames.json music.asm --format ca65 --patterns patterns.json
 python main.py prepare music.asm nes_project/       # Prepare NES project (default mapper: MMC3)
 
-# Other subcommands: `config init|validate`, `song add|list|remove` (multi-song banks), `benchmark run|memory`
+# Other subcommands: `config init|validate`, `song add|list|remove` (JSON song-bank storage/analysis only — not compiled to ROM), `benchmark run|memory`
 ```
 
 ### Testing
@@ -129,7 +129,7 @@ The full pipeline (`run_full_pipeline` in `main.py`) runs everything in a temp d
   - `project_builder.py` - `NESProjectBuilder`: writes main.asm/music.asm/nes.cfg + build scripts
   - `pitch_table.py` - NES frequency tables
   - `envelope_processor.py` - ADSR envelope handling
-  - `song_bank.py` - Multi-song bank support (`song` subcommands)
+  - `song_bank.py` - Song-bank storage/analysis (`song` subcommands; JSON banks only — there is no song-bank → ROM build route yet, see docs/ROADMAP.md)
 
 - **`exporter/`** - Output format generators
   - `exporter_ca65.py` - CA65 assembly export with pattern compression

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,6 +51,15 @@ infrastructure, and the `debug/` diagnostic suite.
 - [ ] FamiStudio export fidelity (effects, pattern organization).
 - [ ] Mapper coverage and auto-selection tuning (NROM/MMC1/MMC3).
 
+### Song banks → ROM
+`SongBank` (`nes/song_bank.py`) is currently **storage/analysis only**: the
+`song add|list|remove` subcommands manage a JSON bank but nothing compiles a
+bank into a `.nes`. Closing the gap (issue #30 / F-13):
+- [ ] `song build <bank> <out.nes>` route through the project builder + compiler.
+- [ ] Real multi-song ROM layout: per-song sequence pointers, a song table, and
+      an in-ROM song-select entry point (today `prepare_multi_song_project` /
+      `add_song_bank` are placeholders that fall back to single-song).
+
 ## 🧭 Mid-term (v0.7.0–v0.9.0)
 
 - [ ] Musical analysis tooling (chord/tempo complexity, instrumentation hints).

--- a/main.py
+++ b/main.py
@@ -484,7 +484,12 @@ def run_full_pipeline(args):
             print(f"   Compression ratio: {pattern_result['stats']['compression_ratio']:.2f}x")
             print(f"   Total patterns detected: {len(pattern_result['patterns'])}")
             print("\n🎮 Your NES ROM is ready to run on emulators or flash carts!")
-            
+
+            # The new ROM is final and validated, so the safety backup is no
+            # longer needed. (On failure it is restored above and kept.)
+            if backup_path:
+                backup_path.unlink(missing_ok=True)
+
         except Exception as e:
             print(f"\n[ERROR] Pipeline failed: {str(e)}")
             if args.verbose:
@@ -563,7 +568,10 @@ def main():
     p_prepare.set_defaults(func=run_prepare)
 
     # Song bank management commands
-    p_song = subparsers.add_parser('song', help='Song bank management')
+    p_song = subparsers.add_parser(
+        'song',
+        help='Song bank management (JSON storage/analysis only; not compiled to ROM)'
+    )
     song_subparsers = p_song.add_subparsers(dest='song_command')
 
     p_song_add = song_subparsers.add_parser('add', help='Add song to bank')

--- a/nes/project_builder.py
+++ b/nes/project_builder.py
@@ -667,9 +667,19 @@ irq:
         return self.mapper.mapper_number == 1
 
     def prepare_multi_song_project(self, music_asm_path: str, segments_data: dict) -> bool:
-        """Legacy: fallback to simple project preparation."""
+        """Placeholder for multi-song ROM builds.
+
+        A true multi-song layout (per-song sequence pointers, a song table, and
+        an in-ROM song-select entry point) is not implemented yet, so this
+        falls back to a single-song project and ignores ``segments_data``. See
+        the song-bank note in docs/ROADMAP.md.
+        """
         return self.prepare_project(music_asm_path)
 
     def add_song_bank(self, song_bank) -> bool:
-        """Legacy compatibility."""
+        """Placeholder for wiring a SongBank into a ROM build.
+
+        No-op until the song-bank -> ROM route exists; SongBank is currently a
+        storage/analysis container only (see nes/song_bank.py).
+        """
         return True

--- a/nes/song_bank.py
+++ b/nes/song_bank.py
@@ -24,6 +24,16 @@ class SongMetadata:
         return True
 
 class SongBank:
+    """In-memory, JSON-backed collection of parsed songs.
+
+    Scope: storage and analysis only. A SongBank parses MIDI files into
+    segments (events/patterns/frames), assigns them to virtual banks, and
+    estimates sizes — but it does NOT compile to a ``.nes``. There is currently
+    no song-bank -> ROM route; the ``song`` CLI subcommands manage the JSON bank
+    only. Multi-song ROM builds are tracked as a planned feature in
+    docs/ROADMAP.md.
+    """
+
     def __init__(self):
         self.songs = {}
         self.current_bank = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,7 @@ from main import (
     run_parse, run_map, run_frames, run_prepare, run_export, 
     run_detect_patterns, run_song_add, run_song_list, run_song_remove,
     load_config, run_config_init, run_config_validate,
-    run_benchmark, run_benchmark_memory, main
+    run_benchmark, run_benchmark_memory, run_full_pipeline, main
 )
 
 
@@ -1049,6 +1049,105 @@ class TestErrorHandling:
         with patch('main.EnhancedTempoMap'):
             with pytest.raises(Exception, match="Detector error"):
                 run_detect_patterns(args)
+
+
+class TestFullPipelineBackupCleanup:
+    """Regression tests for .nes.backup handling in run_full_pipeline (issue #29).
+
+    The backup is created when an output ROM already exists and acts as a
+    rollback safety net: it must be RESTORED and kept on failure, but REMOVED
+    once the new ROM is final on success.
+    """
+
+    def _make_args(self, input_path, output_path):
+        # --no-patterns and --skip-validation keep the pipeline path minimal.
+        return Namespace(
+            input=str(input_path),
+            output=str(output_path),
+            no_patterns=True,
+            arranger=False,
+            verbose=False,
+            debug=False,
+            skip_validation=True,
+        )
+
+    def _common_mocks(self, mock_parse, mock_assign, mock_emu_cls,
+                       mock_exporter_cls, mock_packer_cls, mock_builder_cls):
+        mock_parse.return_value = {"events": {"0": [{"frame": 0, "note": 60}]}}
+        mock_assign.return_value = {}
+        mock_emu = Mock()
+        mock_emu.process_all_tracks.return_value = {"pulse1": {"0": {"note": 60, "volume": 15}}}
+        mock_emu_cls.return_value = mock_emu
+        mock_exporter_cls.return_value = Mock()
+        mock_packer = Mock()
+        mock_packer.generate_assembly.return_value = ""
+        mock_packer.banks = []
+        mock_packer_cls.return_value = mock_packer
+        mock_builder = Mock()
+        mock_builder.prepare_project.return_value = True
+        mock_builder_cls.return_value = mock_builder
+
+    @patch('main.compile_rom')
+    @patch('main.NESProjectBuilder')
+    @patch('dpcm_sampler.dpcm_packer.DpcmPacker')
+    @patch('main.CA65Exporter')
+    @patch('main.NESEmulatorCore')
+    @patch('main.assign_tracks_to_nes_channels')
+    @patch('tracker.parser_fast.parse_midi_to_frames')
+    def test_backup_removed_on_success(self, mock_parse, mock_assign, mock_emu_cls,
+                                       mock_exporter_cls, mock_packer_cls,
+                                       mock_builder_cls, mock_compile):
+        self._common_mocks(mock_parse, mock_assign, mock_emu_cls,
+                           mock_exporter_cls, mock_packer_cls, mock_builder_cls)
+
+        def fake_compile(project_path, out_rom):
+            Path(out_rom).write_bytes(b"\x00" * 1024)
+            return True
+        mock_compile.side_effect = fake_compile
+
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            input_midi = tdp / "song.mid"
+            input_midi.write_bytes(b"MThd")
+            output_rom = tdp / "song.nes"
+            output_rom.write_bytes(b"\x01" * 16)  # pre-existing ROM -> backup created
+            backup_path = output_rom.with_suffix('.nes.backup')
+
+            run_full_pipeline(self._make_args(input_midi, output_rom))
+
+            assert output_rom.exists()
+            assert not backup_path.exists(), ".nes.backup must be removed on success"
+
+    @patch('main.compile_rom')
+    @patch('main.NESProjectBuilder')
+    @patch('dpcm_sampler.dpcm_packer.DpcmPacker')
+    @patch('main.CA65Exporter')
+    @patch('main.NESEmulatorCore')
+    @patch('main.assign_tracks_to_nes_channels')
+    @patch('tracker.parser_fast.parse_midi_to_frames')
+    def test_backup_kept_and_restored_on_compile_failure(self, mock_parse, mock_assign,
+                                                         mock_emu_cls, mock_exporter_cls,
+                                                         mock_packer_cls, mock_builder_cls,
+                                                         mock_compile):
+        self._common_mocks(mock_parse, mock_assign, mock_emu_cls,
+                           mock_exporter_cls, mock_packer_cls, mock_builder_cls)
+        mock_compile.return_value = False  # compilation fails -> rollback path
+
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            input_midi = tdp / "song.mid"
+            input_midi.write_bytes(b"MThd")
+            output_rom = tdp / "song.nes"
+            original = b"\x02" * 16
+            output_rom.write_bytes(original)  # pre-existing ROM -> backup created
+            backup_path = output_rom.with_suffix('.nes.backup')
+
+            with pytest.raises(SystemExit):
+                run_full_pipeline(self._make_args(input_midi, output_rom))
+
+            # On failure the backup is restored over the output and kept on disk.
+            assert backup_path.exists(), ".nes.backup must be kept on failure"
+            assert output_rom.read_bytes() == original, "original ROM must be restored"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…9, #30)

#29 (F-12): run_full_pipeline left a .nes.backup on disk after a successful re-run over an existing ROM. The backup is a rollback safety net (restored on compile/validation failure), so it is now removed once the new ROM is final. Adds regression tests pinning both removal-on-success and restore-on-failure.

#30 (F-13): SongBank is storage/analysis only — no song-bank -> ROM route exists, and prepare_multi_song_project/add_song_bank are placeholders that fall back to single-song. Made the CLI help, class/method docstrings, CLAUDE.md, and ROADMAP say so accurately, and tracked the real multi-song ROM build (song table, per-song sequence pointers, song-select) as a planned feature.