### PR TITLE
fix: clamp pitch timers to t>=8 and DMC level to 7-bit (#24, #27)

### DIFF
--- a/exporter/exporter_ca65.py
+++ b/exporter/exporter_ca65.py
@@ -54,7 +54,9 @@ class CA65Exporter(BaseExporter):
     def midi_note_to_timer_value(self, midi_note):
         if midi_note < 24 or midi_note > 119:  # Valid range for NES
             return 0
-        return NOTE_TABLE_NTSC[midi_note - 24]
+        # Floor at 8: t < 8 silences pulse/triangle, and the top NOTE_TABLE_NTSC
+        # entries are 7 (APU_PULSE_REFERENCE §3/§7).
+        return max(8, NOTE_TABLE_NTSC[midi_note - 24])
 
     def export_direct_frames(self, frames, output_path, standalone=True):
         """Export frames data directly using efficient lookup tables"""
@@ -159,6 +161,12 @@ class CA65Exporter(BaseExporter):
                 else:
                     # Pulse channels: use provided control byte
                     control = frame_data.get('control', 0)
+
+                # Re-assert the audible 11-bit timer range before the byte split.
+                # t < 8 silences pulse/triangle (APU_PULSE_REFERENCE §3/§7), so a
+                # nonzero pitch is floored at 8; a true rest (pitch 0) stays 0.
+                if pitch:
+                    pitch = max(8, min(pitch, 0x07FF))
 
                 note_table.append(f"${note:02X}")
                 control_table.append(f"${control:02X}")
@@ -767,7 +775,12 @@ class CA65Exporter(BaseExporter):
                 duty = (control >> 6) & 0x03
                 
                 dmc_level = frame_data.get('dmc_level') if frame_data else None
-                
+                # $4011 is a 7-bit register (0-127). Mask on read so the value
+                # carried through dedup/storage and emitted as CMD_DMC_LEVEL
+                # never sets bit 7 (out of spec) or overflows the :02X byte.
+                if dmc_level is not None:
+                    dmc_level &= 0x7F
+
                 if frame_data and vol == 0:
                     note = 0
                     

--- a/nes/pitch_table.py
+++ b/nes/pitch_table.py
@@ -26,8 +26,10 @@ def generate_note_table():
         freq = midi_to_freq(midi_note)
         # Calculate timer value
         timer = int(CPU_CLOCK_RATE / (16 * freq) - 1)
-        # Clamp to valid range (0x0000 to 0x07FF)
-        timer = max(0, min(timer, 0x07FF))
+        # Clamp to the audible 11-bit range. The lower bound is 8, NOT 0:
+        # pulse/triangle are silenced whenever timer t < 8 (APU_PULSE_REFERENCE
+        # §3/§7), so the highest MIDI notes must floor at 8 instead of muting.
+        timer = max(8, min(timer, 0x07FF))
         note_table[midi_note] = timer
     
     return note_table
@@ -85,7 +87,8 @@ class PitchProcessor:
         for midi_note in range(128):
             freq = midi_to_freq(midi_note)
             timer = int(CPU_CLOCK_RATE / (16 * freq) - 1)
-            timer = max(0, min(timer, 0x07FF))
+            # Lower bound is 8 (not 0): t < 8 silences pulse/triangle.
+            timer = max(8, min(timer, 0x07FF))
             note_table[midi_note] = timer
         
         return note_table
@@ -122,9 +125,11 @@ class PitchProcessor:
         bend_semitones = (bend_amount / 8192) * 2
         multiplier = 2 ** (bend_semitones / 12)
         
-        # Calculate new timer value (inverse relationship with frequency)
+        # Calculate new timer value (inverse relationship with frequency).
+        # Floor at 8 so an upward bend can't push the timer below the audible
+        # threshold and silence the channel.
         new_timer = int(base_pitch / multiplier)
-        return max(0, min(new_timer, 0x07FF))
+        return max(8, min(new_timer, 0x07FF))
         
     def note_to_timer(self, midi_note):
         """Convert MIDI note to NES timer value."""

--- a/tests/test_ca65_export.py
+++ b/tests/test_ca65_export.py
@@ -36,7 +36,38 @@ class TestCA65Export(unittest.TestCase):
         # Test invalid notes
         self.assertEqual(self.exporter.midi_note_to_timer_value(20), 0)  # Too low
         self.assertEqual(self.exporter.midi_note_to_timer_value(120), 0)  # Too high
-        
+
+    def test_midi_note_to_timer_value_floors_at_8(self):
+        # Regression (NH-06 / #27): the top NOTE_TABLE_NTSC entries are 7, which
+        # silences pulse/triangle (t < 8). In-range notes must floor at 8.
+        self.assertGreaterEqual(self.exporter.midi_note_to_timer_value(118), 8)
+        self.assertGreaterEqual(self.exporter.midi_note_to_timer_value(119), 8)
+        # Out-of-range still returns the 0 "rest" sentinel.
+        self.assertEqual(self.exporter.midi_note_to_timer_value(120), 0)
+
+    def test_dmc_level_clamped_to_7bit(self):
+        # Regression (NH-05 / #24): $4011 is a 7-bit register; an out-of-range
+        # dmc_level must be masked to 0-127 so CMD_DMC_LEVEL never sets bit 7 or
+        # overflows the :02X byte.
+        import re
+        frames = {'dpcm': {'0': {'note': 1, 'volume': 15, 'dmc_level': 200},
+                           '1': {'note': 1, 'volume': 15}}}
+        patterns = {'p0': {'events': [{'note': 1, 'volume': 15}]}}
+        refs = {'0': ('p0', 0)}  # non-empty patterns -> macro bytecode path
+        test_output = Path("test_dmc_clamp.asm")
+        try:
+            self.exporter.export_tables_with_patterns(frames, patterns, refs, test_output)
+            output = test_output.read_text()
+            levels = [int(b, 16) for b in re.findall(
+                r'\.byte \$87, \$([0-9A-Fa-f]{2}) ; CMD_DMC_LEVEL', output)]
+            self.assertTrue(levels, "expected at least one CMD_DMC_LEVEL emission")
+            for lvl in levels:
+                self.assertLessEqual(lvl, 0x7F)
+            self.assertEqual(levels[0], 200 & 0x7F)  # 0x48, not 0xC8
+        finally:
+            if test_output.exists():
+                test_output.unlink()
+
     def test_export_tables_with_patterns(self):
         test_output = Path("test_output.asm")
         try:

--- a/tests/test_pitch_tables.py
+++ b/tests/test_pitch_tables.py
@@ -7,10 +7,33 @@ class TestPitchTables(unittest.TestCase):
         self.processor = PitchProcessor()
 
     def test_note_table_range(self):
-        """Test that note table values are within valid NES timer range"""
+        """Test that note table values are within the audible NES timer range.
+
+        The lower bound is 8, not 0: pulse/triangle are silenced when t < 8.
+        """
         for timer_value in self.processor.note_table.values():
-            self.assertGreaterEqual(timer_value, 0)
+            self.assertGreaterEqual(timer_value, 8)
             self.assertLessEqual(timer_value, 0x07FF)
+
+    def test_high_notes_floor_at_8(self):
+        """Regression (NH-06 / #27): high MIDI notes must floor at timer 8.
+
+        MIDI 127 produced timer 7 before the fix, which silences the channel
+        (t < 8). Both table generators must clamp to >= 8.
+        """
+        from nes.pitch_table import generate_note_table
+        module_table = generate_note_table()
+        for midi_note in range(128):
+            self.assertGreaterEqual(module_table[midi_note], 8)
+            self.assertGreaterEqual(self.processor.note_table[midi_note], 8)
+        # MIDI 127 was the specific offender (timer 7).
+        self.assertGreaterEqual(module_table[127], 8)
+        self.assertGreaterEqual(self.processor.note_table[127], 8)
+
+    def test_pitch_bend_never_mutes(self):
+        """Regression (NH-06 / #27): an upward bend must not push t below 8."""
+        bent = self.processor.apply_pitch_bend(9, 8191, 'pulse1')  # strong up-bend
+        self.assertGreaterEqual(bent, 8)
     
     def test_middle_c(self):
         """Test that middle C (MIDI note 60) produces expected timer value"""


### PR DESCRIPTION
#27 (NH-06): pulse/triangle are silenced when the 11-bit timer t < 8, but the note-table generators floored at 0 and the top entries produced 7 (MIDI 127 in the Python tables; 118/119 in NOTE_TABLE_NTSC). Floor every timer clamp at 8: generate_note_table, PitchProcessor._generate_note_table, apply_pitch_bend, CA65Exporter.midi_note_to_timer_value, and a re-assert before the direct-export byte split. Default pipeline paths clamp notes upstream so this was latent, but the tables are now hardware-correct on every path.

#24 (NH-05): $4011 is a 7-bit register. The CMD_DMC_LEVEL consumer emitted the raw level unmasked, so >= 128 set bit 7 (out of spec) and >= 256 broke the :02X byte. Mask dmc_level to & 0x7F on read so the normalized value flows through dedup, storage, and emission. No producer writes dmc_level yet (that is NH-01); the consumer is kept and now range-safe.

Adds regression tests pinning timer >= 8 for high notes/bends and DMC clamping.