### PR TITLE
fix: share large-file sampling policy across pattern entry points (#21)

### DIFF
--- a/.claude/issues/21/ISSUE.md
+++ b/.claude/issues/21/ISSUE.md
@@ -1,21 +1,9 @@
 # F-09: Asymmetric large-file handling — default path samples/truncates, step-by-step processes the full set unbounded
 
 **Severity:** MEDIUM · **Domain:** pipeline · **Source:** AUDIT_PIPELINE_2026-06-28.md
-**Issue:** #21
 
 ## Description
-Default path silently down-samples to 15000 events inside ParallelPatternDetector (np.linspace, pattern_detector_parallel.py:51-57) and truncates to 2000 in fallback (F-04, main.py:324-326). run_detect_patterns uses EnhancedPatternDetector on the full event set with no threshold and no fallback (main.py:125-147). A large file the default path survives via sampling may hang or OOM under bare detect-patterns.
-
-## Evidence
-pattern_detector_parallel.py:51 MAX_EVENTS = 15000; main.py:130 no size guard.
-
-## Impact
-Inconsistent robustness; the "debugging" subcommand is least robust on large inputs a user would debug. Silent sampling at 15000 is an undocumented lossy step.
-
-## Related
-F-04
+Default path silently down-samples to 15000 events inside ParallelPatternDetector (np.linspace, pattern_detector_parallel.py:51-57) and truncates to 2000 in the fallback (main.py:324-326). run_detect_patterns uses EnhancedPatternDetector on the full event set with no threshold and no fallback (main.py:125-147). A large file the default path survives via sampling may hang/OOM under the bare detect-patterns subcommand.
 
 ## Suggested Fix
-Share one large-file policy across both entry points; make sampling/truncation explicit and warned, or honor --no-patterns consistently.
-
-**Location:** `tracker/pattern_detector_parallel.py:50-58`; `main.py:324-326`; `main.py:125-147`
+Share one large-file policy across both entry points; make sampling/truncation explicit and warned.

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from nes.song_bank import SongBank
 from exporter.exporter_nsf import NSFExporter
 from exporter.exporter_ca65 import CA65Exporter
 from exporter.exporter import generate_famitracker_txt_with_patterns
-from tracker.pattern_detector import EnhancedPatternDetector
+from tracker.pattern_detector import EnhancedPatternDetector, sample_events_for_detection
 from tracker.tempo_map import EnhancedTempoMap
 from dpcm_sampler.enhanced_drum_mapper import EnhancedDrumMapper, DrumMapperConfig
 from config.config_manager import ConfigManager
@@ -149,7 +149,15 @@ def run_detect_patterns(args):
     
     # Sort events by frame number
     events.sort(key=lambda x: x['frame'])
-    
+
+    # Apply the shared large-file policy (#21) so this subcommand stays as
+    # robust as the default pipeline on big inputs instead of running unbounded.
+    original_count = len(events)
+    events, was_sampled = sample_events_for_detection(events)
+    if was_sampled:
+        print(f"⚠️  Large file ({original_count} events): sampled to {len(events)} "
+              f"({len(events)/original_count*100:.1f}%, lossy) before pattern detection")
+
     # Detect patterns
     pattern_result = detector.detect_patterns(events)
     
@@ -327,10 +335,13 @@ def run_full_pipeline(args):
                     print(f"  Parallel detection failed, using fallback: {e}")
                     from tracker.pattern_detector import EnhancedPatternDetector
                     detector = EnhancedPatternDetector(tempo_map, min_pattern_length=PATTERN_MIN_LENGTH, max_pattern_length=PATTERN_MAX_LENGTH)
-                    # For fallback, limit events more conservatively
-                    if len(events) > 2000:
-                        print(f"  Limiting to 2000 events for fallback performance")
-                        events = events[:2000]
+                    # Sequential fallback is slower, so cap more conservatively —
+                    # but sample uniformly (not head-truncate) to keep structure.
+                    FALLBACK_MAX_EVENTS = 2000
+                    fallback_count = len(events)
+                    events, was_sampled = sample_events_for_detection(events, FALLBACK_MAX_EVENTS)
+                    if was_sampled:
+                        print(f"  Sampling {fallback_count} -> {len(events)} events for fallback performance (lossy)")
                     pattern_result = detector.detect_patterns(events)
             else:
                 print("[4/7] Skipping pattern detection (direct export mode)...")

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -626,6 +626,51 @@ class TestPatternSimilarity(unittest.TestCase):
         self.assertEqual(variations[1]['volume_change'], -20, "Should detect volume change")
 
 
+class TestLargeFilePolicy(unittest.TestCase):
+    """Both pattern-detection entry points must apply the same large-file
+    sampling policy so a big input cannot hang the bare subcommand while the
+    default path survives via sampling (#21)."""
+
+    def test_small_input_is_not_sampled(self):
+        from tracker.pattern_detector import sample_events_for_detection
+        events = [{'frame': i, 'note': 60, 'volume': 100} for i in range(100)]
+        out, was_sampled = sample_events_for_detection(events)
+        self.assertFalse(was_sampled)
+        self.assertEqual(out, events)
+
+    def test_large_input_is_downsampled_uniformly(self):
+        from tracker.pattern_detector import (
+            sample_events_for_detection, MAX_PATTERN_EVENTS)
+        events = [{'frame': i, 'note': 60, 'volume': 100}
+                  for i in range(MAX_PATTERN_EVENTS + 5000)]
+        out, was_sampled = sample_events_for_detection(events)
+        self.assertTrue(was_sampled)
+        self.assertEqual(len(out), MAX_PATTERN_EVENTS)
+        # Uniform sampling preserves the endpoints (temporal distribution),
+        # unlike head-truncation which would drop the entire tail.
+        self.assertEqual(out[0], events[0])
+        self.assertEqual(out[-1], events[-1])
+
+    def test_custom_cap_is_honored(self):
+        from tracker.pattern_detector import sample_events_for_detection
+        events = [{'frame': i, 'note': 60, 'volume': 100} for i in range(5000)]
+        out, was_sampled = sample_events_for_detection(events, 2000)
+        self.assertTrue(was_sampled)
+        self.assertEqual(len(out), 2000)
+
+    def test_both_entry_points_share_the_sampler(self):
+        import inspect
+        import main
+        from tracker.pattern_detector_parallel import ParallelPatternDetector
+
+        sub = inspect.getsource(main.run_detect_patterns)
+        par = inspect.getsource(ParallelPatternDetector.detect_patterns)
+        self.assertIn('sample_events_for_detection', sub,
+                      "detect-patterns subcommand must apply the shared sampler")
+        self.assertIn('sample_events_for_detection', par,
+                      "parallel default path must apply the shared sampler")
+
+
 class TestPatternParameterConsistency(unittest.TestCase):
     """Both pattern-detection entry points (the `detect-patterns` subcommand and
     the default full pipeline) must use identical length bounds so their JSON

--- a/tracker/pattern_detector.py
+++ b/tracker/pattern_detector.py
@@ -1,8 +1,31 @@
 # tracker/pattern_detector.py
 from collections import defaultdict
 from typing import List, Dict, Tuple
+import numpy as np
 from tqdm import tqdm
 from tracker.tempo_map import TempoChangeType, TempoChange, EnhancedTempoMap
+
+# Shared large-file policy. Pattern detection is O(n^2)-ish in the number of
+# events, so very large inputs are uniformly down-sampled to this many events
+# before detection. This is LOSSY — see docs/legacy/PATTERN_DETECTION_IMPROVEMENTS.md.
+# Both entry points (the `detect-patterns` subcommand and the default full
+# pipeline) must apply this same policy so they agree on large inputs (#21).
+MAX_PATTERN_EVENTS = 15000
+
+
+def sample_events_for_detection(events, max_events=MAX_PATTERN_EVENTS):
+    """Uniformly down-sample ``events`` to at most ``max_events`` entries.
+
+    Sampling is spread across the whole sequence (``np.linspace``) so the
+    musical structure is preserved rather than head-truncated. This is a lossy
+    step; callers should surface a warning when it triggers.
+
+    Returns ``(sampled_events, was_sampled)``.
+    """
+    if len(events) <= max_events:
+        return events, False
+    indices = np.linspace(0, len(events) - 1, max_events, dtype=int)
+    return [events[i] for i in indices], True
 
 class PatternDetector:
     def __init__(self, min_pattern_length=3, max_pattern_length=32):

--- a/tracker/pattern_detector_parallel.py
+++ b/tracker/pattern_detector_parallel.py
@@ -4,10 +4,9 @@ import time
 from typing import List, Dict, Tuple, Any, Optional
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
-import numpy as np
 from tqdm import tqdm
 from tracker.tempo_map import EnhancedTempoMap
-from tracker.pattern_detector import PatternCompressor
+from tracker.pattern_detector import PatternCompressor, sample_events_for_detection
 
 class ParallelPatternDetector:
     """
@@ -44,20 +43,18 @@ class ParallelPatternDetector:
         if not valid_events:
             return self._empty_result()
         
+        # Handle large sequences using the shared large-file policy (#21) so the
+        # default path and the `detect-patterns` subcommand sample identically.
+        original_count = len(valid_events)
+        valid_events, was_sampled = sample_events_for_detection(valid_events)
+        if was_sampled:
+            print(f"⚠️  Large sequence ({original_count} events), sampling to "
+                  f"{len(valid_events)} ({len(valid_events)/original_count*100:.1f}%, lossy)")
+            print(f"   ✅ Sampled {len(valid_events)} events preserving temporal distribution")
+
         # Convert to sequence for processing
         sequence = [(e['note'], e['volume']) for e in valid_events]
-        
-        # Handle large sequences - increase limit and provide better sampling
-        MAX_EVENTS = 15000  # Increased significantly for better music preservation
-        if len(sequence) > MAX_EVENTS:
-            print(f"⚠️  Large sequence ({len(sequence)} events), using optimized sampling for {MAX_EVENTS} events")
-            print(f"   Original events: {len(sequence)}, Will sample: {MAX_EVENTS} ({MAX_EVENTS/len(sequence)*100:.1f}%)")
-            # Smart sampling: take events from throughout the sequence to preserve structure
-            indices = np.linspace(0, len(sequence)-1, MAX_EVENTS, dtype=int)
-            sequence = [sequence[i] for i in indices]
-            valid_events = [valid_events[i] for i in indices]
-            print(f"   ✅ Sampled {len(sequence)} events preserving temporal distribution")
-        
+
         # Split work into chunks for parallel processing
         patterns = self._detect_patterns_parallel(sequence, valid_events)
         


### PR DESCRIPTION
run_detect_patterns ran EnhancedPatternDetector on the full event set with no size guard, while the default pipeline down-sampled to 15000 events inside ParallelPatternDetector. A large MIDI the default path survives via sampling could hang or OOM under the bare detect-patterns subcommand.

Extract the sampling into a shared sample_events_for_detection() helper (MAX_PATTERN_EVENTS=15000, uniform np.linspace sampling) in pattern_detector.py and apply it in all three sites: the detect-patterns subcommand, the parallel default path, and the sequential fallback (now uniform-sampled instead of head-truncated). Every site surfaces an explicit lossy-sampling warning.