### PR TITLE
fix: emit DPCM index id as sample_id, not allocation counter (#65)

### DIFF
--- a/dpcm_sampler/enhanced_drum_mapper.py
+++ b/dpcm_sampler/enhanced_drum_mapper.py
@@ -286,14 +286,16 @@ class EnhancedDrumMapper:
                 if sample_name and sample_name in self.sample_index:
                     sample_data = self.sample_index[sample_name]
                     
-                    # Use sample manager for allocation
-                    allocated_sample = self.sample_manager.allocate_sample(
-                        sample_name, sample_data
-                    )
-                    
+                    # Run allocation for its usage/eviction side effects, but emit
+                    # the index id — that is what the packer orders its tables by
+                    # (sorted by dpcm_index.json 'id'), so it is the value the
+                    # engine uses to index dpcm_*_table. The manager's allocation
+                    # counter is a different id space (see issue #65).
+                    self.sample_manager.allocate_sample(sample_name, sample_data)
+
                     dpcm_events.append({
                         "frame": frame,
-                        "sample_id": allocated_sample['id'],
+                        "sample_id": sample_data['id'],
                         "velocity": velocity
                     })
                     
@@ -351,13 +353,13 @@ class EnhancedDrumMapper:
         
         if sample_name and sample_name in self.sample_index:
             sample_data = self.sample_index[sample_name]
-            allocated_sample = self.sample_manager.allocate_sample(
-                sample_name, sample_data
-            )
-            
+            # Index id (not the manager's allocation counter) indexes the packer
+            # tables — see issue #65.
+            self.sample_manager.allocate_sample(sample_name, sample_data)
+
             events.append({
                 "frame": frame,
-                "sample_id": allocated_sample['id'],
+                "sample_id": sample_data['id'],
                 "velocity": int(velocity),
                 "pattern_id": pattern_id
             })
@@ -388,13 +390,13 @@ class EnhancedDrumMapper:
         for layer in layers:
             if layer in self.sample_index:
                 sample_data = self.sample_index[layer]
-                allocated_sample = self.sample_manager.allocate_sample(
-                    layer, sample_data
-                )
-                
+                # Index id (not the manager's allocation counter) indexes the
+                # packer tables — see issue #65.
+                self.sample_manager.allocate_sample(layer, sample_data)
+
                 events.append({
                     "frame": frame,
-                    "sample_id": allocated_sample['id'],
+                    "sample_id": sample_data['id'],
                     "velocity": velocity
                 })
 

--- a/tests/test_drum_mapping.py
+++ b/tests/test_drum_mapping.py
@@ -35,6 +35,30 @@ class TestDrumMapping(unittest.TestCase):
         self.assertIsNotNone(kick_hard_velocity_sample, "Should have kick_hard sample for high velocity")
         self.assertIsNotNone(kick_soft_velocity_sample, "Should have kick_soft sample for low velocity")
         
+    def test_sample_id_is_index_id_not_allocation_order(self):
+        """Regression for #65: emitted sample_id must equal the dpcm_index.json
+        'id' (which the packer orders its tables by), never the sample
+        manager's allocation counter. Allocate snare (index id 4) before kick
+        (index id 0); if sample_id followed allocation order the first event
+        would be 0 and the second 1 — both wrong."""
+        with open(self.test_index_path) as f:
+            index = json.load(f)
+        snare_id = index["snare"]["id"]
+        kick_id = index["kick"]["id"]
+        self.assertNotEqual(snare_id, 0,
+                            "fixture must have snare at a non-zero id for this test to bite")
+
+        events = {9: [
+            {"frame": 0, "note": 38, "velocity": 100},   # snare first
+            {"frame": 10, "note": 36, "velocity": 100},  # kick second
+        ]}
+        dpcm_events, _ = map_drums_to_dpcm(
+            events, self.test_index_path, use_advanced=False
+        )
+        by_frame = {e["frame"]: e["sample_id"] for e in dpcm_events}
+        self.assertEqual(by_frame[0], snare_id)   # index id, not allocation 0
+        self.assertEqual(by_frame[10], kick_id)   # index id, not allocation 1
+
     def test_missing_index_file(self):
         with self.assertRaises(FileNotFoundError):
             map_drums_to_dpcm(self.test_events, "nonexistent.json")


### PR DESCRIPTION
EnhancedDrumMapper emitted dpcm_events[...]['sample_id'] from the sample manager's allocate_sample() return, whose 'id' is len(active_samples) — a 0,1,2… counter in allocation order. But the packer orders dpcm_bank/pitch/ addr/len tables by sorted(metadata.keys(), key=int), i.e. the dpcm_index.json 'id'. The engine recovers y = sample_id and indexes those tables, so once samples actually load (after #64) every drum hit pointed at whatever sample occupied the allocation slot, not the one the MIDI asked for.

Emit sample_data['id'] (the index id the packer tables are keyed by) at all three emission sites (regular, pattern, layered). allocate_sample is still called for its usage/eviction side effects; only the id space changed.

Add a regression test that allocates a high-index drum (snare, id 4) before a low-index one (kick, id 0) and asserts sample_id follows the index id, not allocation order.