### PR TITLE
fix: pack only song-referenced DPCM samples instead of entire 1923-entry catalog (#140)

### DIFF
--- a/dpcm_sampler/generate_dpcm_index.py
+++ b/dpcm_sampler/generate_dpcm_index.py
@@ -35,7 +35,8 @@ def resolve_dpcm_sample_path(filename, index_path):
     return None
 
 
-def load_dpcm_index_into_packer(packer, dpcm_index, index_path, verbose=False):
+def load_dpcm_index_into_packer(packer, dpcm_index, index_path, verbose=False,
+                                sample_ids=None):
     """Resolve every entry in ``dpcm_index`` and add it to ``packer``.
 
     Shared by both DPCM packing call sites so the same robustness rules apply at
@@ -45,6 +46,9 @@ def load_dpcm_index_into_packer(packer, dpcm_index, index_path, verbose=False):
       missing is skipped with an optional warning.
     - Samples longer than the NES 4081-byte DMC limit are truncated rather than
       raising, so one oversized sample never aborts the whole pack (#68).
+    - When ``sample_ids`` is provided (a set of ints or strings), only entries
+      whose ``id`` matches are loaded. This prevents packing the entire 1923-entry
+      shipped catalog for songs that only use a handful of samples (#140).
 
     Samples are added in ascending index-id order, matching the positional
     lookup tables the engine indexes by ``sample_id``. Returns
@@ -53,6 +57,10 @@ def load_dpcm_index_into_packer(packer, dpcm_index, index_path, verbose=False):
     loaded = 0
     skipped = 0
     for sample in sorted(dpcm_index.values(), key=lambda s: int(s['id'])):
+        sid = sample['id']
+        sid_int = int(sid) if not isinstance(sid, int) else sid
+        if sample_ids is not None and sid_int not in sample_ids:
+            continue
         sample_path = resolve_dpcm_sample_path(sample['filename'], index_path)
         if sample_path is None:
             skipped += 1
@@ -60,7 +68,7 @@ def load_dpcm_index_into_packer(packer, dpcm_index, index_path, verbose=False):
                 print(f"  ⚠️ Warning: DPCM sample not found: {sample['filename']}")
             continue
         packer.add_sample(
-            str(sample['id']),
+            str(sid),
             str(sample_path.absolute()).replace('\\', '/'),
             sample.get('pitch', 15),
             truncate=True,
@@ -90,6 +98,22 @@ def generate_dpcm_index(dmc_folder, output_json):
         json.dump(index, f, indent=2)
 
     print(f"Indexed {len(index)} DPCM samples → {output_json}")
+
+
+def get_dpcm_sample_ids_from_frames(frames):
+    """Extract the set of DPCM sample IDs referenced in frame data.
+
+    Frame DPCM entries encode ``note = sample_id + 1`` (0 is the rest/change
+    sentinel).  Returns a ``set[int]`` of the sample IDs actually used, which
+    callers can pass to ``load_dpcm_index_into_packer(sample_ids=...)``.
+    """
+    ids = set()
+    for frame_data in frames.get('dpcm', {}).values():
+        note = frame_data.get('note', 0)
+        if note and int(note) > 0:
+            ids.add(int(note) - 1)
+    return ids
+
 
 if __name__ == "__main__":
     import sys

--- a/main.py
+++ b/main.py
@@ -280,13 +280,20 @@ def run_export(args):
         # Pack DPCM samples for exported ASM
         try:
             from dpcm_sampler.dpcm_packer import DpcmPacker
-            from dpcm_sampler.generate_dpcm_index import load_dpcm_index_into_packer
+            from dpcm_sampler.generate_dpcm_index import (
+                load_dpcm_index_into_packer,
+                get_dpcm_sample_ids_from_frames,
+            )
             packer = DpcmPacker()
             dpcm_index_path = Path('dpcm_index.json')
             if dpcm_index_path.exists():
                 with open(dpcm_index_path, 'r') as f:
                     dpcm_index = json.load(f)
-                loaded_samples, _ = load_dpcm_index_into_packer(packer, dpcm_index, dpcm_index_path)
+                sample_ids = get_dpcm_sample_ids_from_frames(frames)
+                loaded_samples, _ = load_dpcm_index_into_packer(
+                    packer, dpcm_index, dpcm_index_path,
+                    sample_ids=sample_ids or None,
+                )
                 if loaded_samples == 0 and dpcm_index:
                     print(f" Warning: dpcm_index.json has {len(dpcm_index)} entries but none resolved to a file — DPCM tables will be empty (percussion silent).")
                 with open(args.output, 'a') as f:
@@ -557,7 +564,10 @@ def run_full_pipeline(args):
             print("[5.5/7] Packing DPCM samples...")
             try:
                 from dpcm_sampler.dpcm_packer import DpcmPacker
-                from dpcm_sampler.generate_dpcm_index import load_dpcm_index_into_packer
+                from dpcm_sampler.generate_dpcm_index import (
+                    load_dpcm_index_into_packer,
+                    get_dpcm_sample_ids_from_frames,
+                )
                 packer = DpcmPacker()
                 dpcm_index_path = Path('dpcm_index.json')
 
@@ -565,10 +575,12 @@ def run_full_pipeline(args):
                     with open(dpcm_index_path, 'r') as f:
                         dpcm_index = json.load(f)
 
-                    # Resolve + add every sample (truncating oversized ones, #68)
-                    # in ascending id order so they align with the engine's tables.
+                    # Only pack samples the song actually uses (#140).
+                    sample_ids = get_dpcm_sample_ids_from_frames(frames)
                     loaded_samples, _ = load_dpcm_index_into_packer(
-                        packer, dpcm_index, dpcm_index_path, verbose=args.verbose
+                        packer, dpcm_index, dpcm_index_path,
+                        sample_ids=sample_ids or None,
+                        verbose=args.verbose,
                     )
 
                     # Generate the lookup tables and binary includes, append to music.asm


### PR DESCRIPTION
Closes #140

The DPCM packer was loading ALL 1923 entries from dpcm_index.json into every ROM, which far exceeds the 60 × 8 KB = 480 KB DPCM bank budget. This caused an OverflowError that was swallowed by a broad except, resulting in silent percussion on every drummed song.

Now only the DPCM samples actually referenced in the song's frame data are packed. A new `get_dpcm_sample_ids_from_frames()` helper extracts the sample IDs from frame `note` values (where `note = sample_id + 1`, with 0 as the rest sentinel), and `load_dpcm_index_into_packer()` accepts an optional `sample_ids` parameter to filter the index.

Both call sites (`run_export` and `run_full_pipeline`) are updated to extract used sample IDs from frames and pass them through. The `sample_ids` parameter defaults to `None` for backward compatibility.

**Verification**
- 38 DPCM-related existing tests pass
- Manual validation confirms filtering works correctly (6 test scenarios)
- Existing test suite: 51 passed, 8 failed (all 8 failures are pre-existing CC65 compiler missing on Windows)
