### PR TITLE
fix: correct standalone DPCM rest guard and drop the 0-95 sample_id c…

### DIFF
--- a/.claude/issues/66/ISSUE.md
+++ b/.claude/issues/66/ISSUE.md
@@ -1,42 +1,12 @@
 # D-03: Standalone play_dpcm tests stale Z flag — rest sentinel triggers bogus sample $FF
+Severity: HIGH · Domain: dpcm · Source: AUDIT_DPCM_2026-06-29.md
 
-Issue: #66 — https://github.com/matiaszanolli/midi2nes/issues/66
-Labels: bug, high, dpcm
-Filed from: AUDIT_DPCM_2026-06-29.md
-
----
-
-**Severity:** HIGH · **Domain:** dpcm · **Source:** AUDIT_DPCM_2026-06-29.md
-
-## Description
-The direct-export (`export_direct_frames`, `standalone=True`, reachable via `--no-patterns`) `play_dpcm` routine:
-```asm
-lda (temp_ptr),y      ; A = note (sample_id+1, 0 = rest)
-cmp last_dpcm_note    ; Z set iff note == last
-beq @done             ; unchanged -> skip
-sta last_dpcm_note    ; STA does NOT affect Z
-beq @done             ; "note 0 -> nothing to trigger"  <-- tests stale cmp Z
-; New sample: sample_id = note - 1
-sec / sbc #1 / tay ...
-```
-The second `beq @done` (line 679) is meant to skip when the new note is 0, but `STA` leaves the flags from the preceding `CMP` untouched. Control only reaches line 678 when the `CMP` was *not* equal (the first `beq` at line 677 didn't branch), so Z=0 and the second `beq` **never** fires. A rest (`note == 0`) that differs from `last_dpcm_note` falls through to `sbc #1` → `y = $FF`, triggering `dpcm_*_table[$FF]` — out-of-table garbage.
-
-## Location
-`exporter/exporter_ca65.py:675-683`
-
-## Evidence
-`exporter_ca65.py:676-679`. Contrast the project-builder engine `nes/audio_engine.asm:314-316`, which correctly guards with `lda current_note,x / bne :+ / jmp @silence` *before* dispatching to `@write_dpcm`.
-
-## Impact
-In the `--no-patterns` direct-export ROM, every transition from a sample back to silence re-fires a wrong/garbage sample id, producing spurious DPCM noise. Project-builder bytecode path is unaffected.
-
-## Hardware ref
-`docs/APU_DMC_REFERENCE.md` §3 (a `$4015` bit-4 trigger starts the reader from the programmed `$4012`/`$4013`; an out-of-range table index yields an arbitrary address/length).
-
-## Suggested Fix
-Reorder to test the note value, e.g. `lda (temp_ptr),y / cmp last_dpcm_note / beq @done / tax / sta last_dpcm_note / txa / beq @done`, or `pha`/`tax` to re-set Z from the note before the second branch.
-
-## Completeness Checks
-- [ ] **RANGE**: emitted sample index stays within the packed-table bounds (no $FF over-read)
-- [ ] **SIBLING**: Same guard pattern checked in the project-builder engine path
-- [ ] **TESTS**: A regression test pins this specific fix
+export_direct_frames standalone=True play_dpcm:
+  lda (temp_ptr),y ; note (sample_id+1, 0=rest)
+  cmp last_dpcm_note / beq @done
+  sta last_dpcm_note  ; STA does NOT affect Z
+  beq @done           ; meant "note 0 -> skip" but Z still from CMP (not equal) -> never fires
+  sec / sbc #1 / tay  ; rest note 0 -> y=$FF -> dpcm_*_table[$FF] over-read
+Location: exporter/exporter_ca65.py:675-683. Engine guards correctly
+(nes/audio_engine.asm:314-316: lda current_note / bne :+ / jmp @silence).
+Fix: re-set Z from the note value before the second branch (tax/txa or pha).

--- a/.claude/issues/67/ISSUE.md
+++ b/.claude/issues/67/ISSUE.md
@@ -1,37 +1,9 @@
 # D-04: Emulator clamps sample_id to 94 — high-id drums collapse to one wrong sample
+Severity: HIGH · Domain: dpcm · Source: AUDIT_DPCM_2026-06-29.md
 
-Issue: #67 — https://github.com/matiaszanolli/midi2nes/issues/67
-Labels: bug, high, dpcm
-Filed from: AUDIT_DPCM_2026-06-29.md
-
----
-
-**Severity:** HIGH · **Domain:** dpcm · **Source:** AUDIT_DPCM_2026-06-29.md
-
-## Description
-`process_all_tracks` stores the dpcm trigger as `note = min(95, sample_id + 1)`. The index ships 1923 samples (ids 0–1922), and the drum mapper can emit any allocated id. Any `sample_id >= 94` is silently clamped to note 95 → `sample_id = 94` in the engine. The bytecode path repeats the clamp (`if note > 95: note = 95`, line 952). The clamp was presumably borrowed from the tone-channel MIDI-note range (0–95), but a DPCM `sample_id` is **not** a MIDI note and has no such ceiling.
-
-## Location
-- `nes/emulator_core.py:124` (`"note": min(95, sample_id + 1)`)
-- compounded by `exporter/exporter_ca65.py:952-953`
-
-## Evidence
-`emulator_core.py:124`; `dpcm_index.json` has 1923 entries; the manager can allocate up to `max_samples` (default 16) distinct ids but those ids still index a table built from the full index — see D-02.
-
-## Impact
-Any song using more than ~94 distinct DPCM samples (or, post-D-02-fix, any index id ≥ 94) silently maps every high-id hit to a single wrong sample. Audible drum substitution with no warning.
-
-## Hardware ref
-`docs/APU_DMC_REFERENCE.md` §2 — DPCM selection is by sample address/length tables, not a 7-bit note; there is no MIDI-note ceiling on a sample index.
-
-## Related
-D-02 (id-space mismatch).
-
-## Suggested Fix
-Don't reuse the 0–95 MIDI-note clamp for DPCM. Bound `sample_id` by the real packed-sample count (or use a 2-byte index), and route through the correct index id per D-02.
-
-## Completeness Checks
-- [ ] **RANGE**: sample index bounded by the real packed-sample count, not the 0–95 note range
-- [ ] **CONTRACT**: emulator_core and bytecode exporter agree on the bound
-- [ ] **SIBLING**: Same clamp checked in emulator_core and exporter_ca65
-- [ ] **TESTS**: A regression test pins this specific fix
+process_all_tracks stores note = min(95, sample_id+1) reusing the 0-95 MIDI-note
+ceiling. sample_id is NOT a MIDI note. Any sample_id>=94 clamps to note 95 -> id 94.
+Compounded by exporter_ca65.py:952-953 (if note>95: note=95).
+Location: nes/emulator_core.py:124; exporter/exporter_ca65.py:952-953.
+Fix: bound sample_id by real format/byte range, not 0-95 note ceiling; emulator_core
+and bytecode exporter must agree. CONTRACT + SIBLING.

--- a/exporter/exporter_ca65.py
+++ b/exporter/exporter_ca65.py
@@ -704,8 +704,9 @@ class CA65Exporter(BaseExporter):
                 '    lda (temp_ptr),y',
                 '    cmp last_dpcm_note',
                 '    beq @done            ; unchanged - sample already triggered',
-                '    sta last_dpcm_note',
-                '    beq @done            ; note 0 -> nothing to trigger',
+                '    sta last_dpcm_note   ; NB: STA does not affect Z',
+                '    cmp #0               ; re-test the note (A still holds it); STA left the stale CMP flags (#66)',
+                '    beq @done            ; note 0 (rest) -> nothing to trigger, no dpcm_*_table[$FF] over-read',
                 '    ; New sample: sample_id = note - 1',
                 '    sec',
                 '    sbc #1',
@@ -978,9 +979,18 @@ class CA65Exporter(BaseExporter):
                 if frame_data and vol == 0:
                     note = 0
                     
-                if note > 95:
+                # The DPCM channel's `note` is sample_id + 1, not a MIDI note, so
+                # it is bounded only by the single-byte frame format (<= 255), not
+                # the 0-95 tone-note range — clamping it to 95 collapsed high-id
+                # drums to one wrong sample (#67). Tone channels keep the note
+                # ceiling. Either way `note` stays a single byte so the `${note:02X}`
+                # operand below can never widen past two hex digits.
+                if channel == 'dpcm':
+                    if note > 255:
+                        note = 255
+                elif note > 95:
                     note = 95
-                    
+
                 dmc_changed = False
                 if dmc_level is not None and dmc_level != current_dmc_level:
                     dmc_changed = True

--- a/nes/emulator_core.py
+++ b/nes/emulator_core.py
@@ -120,8 +120,14 @@ class NESEmulatorCore:
                     if velocity <= 0:
                         continue
                     sample_id = e.get('sample_id', 0)
+                    # A DPCM sample_id is NOT a MIDI note, so it must not borrow
+                    # the 0-95 tone-note ceiling — that collapsed every id >= 94
+                    # to one wrong sample (#67). The real bound is the single-byte
+                    # frame `note` field: note = sample_id + 1 in [1, 255] (0 is the
+                    # rest sentinel), so sample_id addresses up to 254. The exporter
+                    # applies the same byte ceiling for the dpcm channel.
                     frame = {
-                        "note": min(95, sample_id + 1),
+                        "note": min(255, sample_id + 1),
                         "volume": 15,
                     }
                     if 'dmc_level' in e:

--- a/tests/test_audio_fixes.py
+++ b/tests/test_audio_fixes.py
@@ -96,6 +96,62 @@ class TestNoiseDpcmReachAPU(unittest.TestCase):
         self.assertIn('sta $4013', content)   # DMC length
         self.assertIn('dpcm_note:', content)
 
+    def test_high_sample_id_not_clamped_to_note_95(self):
+        # Regression (D-04 / #67): a DPCM sample_id is not a MIDI note, so it must
+        # not borrow the 0-95 tone-note ceiling. sample_id 200 used to clamp to
+        # note 95 (sample_id 94) — a wrong drum. The bound is the single-byte
+        # frame note: note = sample_id + 1.
+        mapped = {'dpcm': [{'frame': 0, 'note': 36, 'velocity': 100, 'sample_id': 200}]}
+        frames = self.core.process_all_tracks(mapped)
+        self.assertEqual(frames['dpcm'][0]['note'], 201)   # not 95
+        # The byte format still caps at 255 so the emitted operand stays one byte.
+        big = {'dpcm': [{'frame': 0, 'note': 36, 'velocity': 100, 'sample_id': 9999}]}
+        self.assertEqual(self.core.process_all_tracks(big)['dpcm'][0]['note'], 255)
+
+    def test_bytecode_dpcm_high_note_survives_tone_note_still_clamped(self):
+        # Regression (D-04 / #67): the bytecode serializer's note clamp must be
+        # channel-aware — DPCM keeps its high sample-id note (bounded only by the
+        # byte format), while a tone channel still clamps to the 0-95 note range.
+        frames = {
+            'dpcm':   {'0': {'note': 201, 'volume': 15}},   # sample_id 200
+            'pulse1': {'0': {'note': 100, 'volume': 8}},    # tone note > 95
+        }
+        patterns = {'p0': {'events': [{'note': 10, 'volume': 8}], 'positions': [0]}}
+        refs = {'0': ('p0', 0)}
+        out = tempfile.mktemp(suffix='.asm')
+        try:
+            self.exporter.export_tables_with_patterns(frames, patterns, refs, out, standalone=False)
+            content = Path(out).read_text()
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+        dpcm_block = content.split('dpcm_sequence:')[1].split('\n\n')[0]
+        self.assertIn('Note 201', dpcm_block)   # not collapsed to 95
+        self.assertIn('$C9', dpcm_block)         # 201 emitted as a single byte
+        pulse_block = content.split('pulse1_sequence:')[1].split('_sequence:')[0]
+        self.assertIn('Note 95', pulse_block)    # tone note still clamped
+
+    def test_direct_play_dpcm_rest_guard_re_tests_note(self):
+        # Regression (D-03 / #66): the standalone play_dpcm rest guard tested the
+        # stale Z flag from `cmp last_dpcm_note` (STA does not affect Z), so a rest
+        # (note 0) that differs from the last note fell through to `sbc #1` -> y=$FF
+        # -> dpcm_*_table[$FF] over-read. The guard must re-set Z from the note.
+        mapped = {'dpcm': [{'frame': 0, 'note': 36, 'velocity': 100, 'sample_id': 1}]}
+        frames = self.core.process_all_tracks(mapped)
+        out = tempfile.mktemp(suffix='.asm')
+        try:
+            self.exporter.export_direct_frames(frames, out, standalone=True)
+            content = Path(out).read_text()
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+        proc = content.split('.proc play_dpcm')[1].split('.endproc')[0]
+        # Between storing last_dpcm_note and deriving sample_id (sbc #1), the note
+        # value must be re-tested so the rest (note 0) skips the trigger.
+        guard = proc[proc.index('sta last_dpcm_note'):proc.index('sbc #1')]
+        self.assertIn('cmp #0', guard)
+        self.assertIn('beq @done', guard)
+
 
 @unittest.skip("Obsolete: Assembly generation changed to MMC3 Macro Bytecode")
 class TestTriangleControlByte(unittest.TestCase):


### PR DESCRIPTION
…lamp (#66, #67)

Two HIGH DPCM bugs in the same note/sample_id contract:

#66 (D-03) — the standalone play_dpcm rest guard tested a stale flag. After `cmp last_dpcm_note` / `beq @done` / `sta last_dpcm_note`, the second `beq @done` (meant to skip a rest, note 0) read the Z flag from the CMP, but STA does not touch the flags and control only reaches it when CMP was not-equal (Z=0) — so it never fired. A rest that differed from the last note fell through to `sbc #1`, giving y=$FF and a dpcm_*_table[$FF] over-read (spurious sample on every sample->silence transition). Re-test the note (`cmp #0`, A still holds it) before the branch. The project-builder engine path already guards correctly (audio_engine.asm: lda current_note / bne / jmp @silence), so it was unaffected.

#67 (D-04) — process_all_tracks stored note = min(95, sample_id + 1), borrowing the 0-95 tone-note ceiling for a value that is not a MIDI note, collapsing every sample_id >= 94 to one wrong drum. The bytecode exporter repeated the clamp. The real bound is the single-byte frame note (note = sample_id + 1 in [1, 255]): bump emulator_core to min(255, ...) and make the exporter clamp channel-aware (dpcm keeps its high note, capped at the byte format; tone channels still clamp to 95 so the `${note:02X}` operand stays one byte). emulator_core and the exporter now agree on the 255 ceiling.

Regression tests cover the play_dpcm re-test, the emulator bound (sample_id 200 -> note 201, 9999 -> 255), and the channel-aware bytecode clamp.