### PR TITLE
fix: reject SMPTE division and stop dropping valid tempo changes (#93…

### DIFF
--- a/.claude/issues/93/ISSUE.md
+++ b/.claude/issues/93/ISSUE.md
@@ -1,34 +1,10 @@
 # TEMPO-01: SMPTE / negative ticks_per_beat produces negative frame indices
+Severity: HIGH · Domain: tempo · Source: AUDIT_TEMPO_2026-06-29.md
 
-Issue: #93
-
-**Severity:** HIGH · **Domain:** tempo · **Source:** AUDIT_TEMPO_2026-06-29.md
-
-## Description
-`parse_midi_to_frames` passes `ticks_per_beat=mid.ticks_per_beat` to `EnhancedTempoMap` with no validation (`tracker/parser_fast.py:24-29`). For SMPTE-division MIDI files (division word with bit 15 set), **mido returns `ticks_per_beat` as a negative integer**. `calculate_time_ms` (`tracker/tempo_map.py:129`) then computes `us_per_tick = tempo / ticks_per_beat < 0`, so elapsed time is negative and `round(time_ms / FRAME_MS)` in `get_frame_for_tick` (`:144-147`) yields **negative frame indices**. Nothing downstream guards against a negative `frame`, so events are written at negative JSON keys / negative `range()` bounds and silently corrupt the song.
-
-## Location
-`tracker/parser_fast.py:24-29` (and `:14` where `mid = mido.MidiFile`); consumed in `tracker/tempo_map.py:129` and `:144-147`.
-
-## Evidence
-Constructed a raw SMPTE header (`division = -3200`); `mido.MidiFile` parsed it with `ticks_per_beat == -3200`. Then:
-```
-EnhancedTempoMap(initial_tempo=500000, ticks_per_beat=-3200, optimization_strategy=None)
-tm.calculate_time_ms(0, 6400)  -> -1000.0
-tm.get_frame_for_tick(6400)    -> -60
-```
-
-## Impact
-Any SMPTE-timed MIDI (legal, exported by some DAWs/notation tools) compiles to garbage: notes at negative frames, wrong total length, likely silent or scrambled playback. Blast radius is the whole song, at the parse stage, for every channel. No error surfaces.
-
-## Related
-TEMPO-03 (`ticks_per_beat == 0` from same unvalidated boundary); SAFE-07 in `docs/audits/AUDIT_SAFETY_2026-06-29.md` (per-event drop, different line).
-
-## Suggested Fix
-In `parse_midi_to_frames`, after opening the file, check `mid.ticks_per_beat > 0`; if mido reports a non-metrical (SMPTE) division, either raise a clear error or convert SMPTE frame/sub-frame timing to a positive PPQ before constructing the tempo map. Add an assertion in `TempoMap.__init__` that `ticks_per_beat >= 1`.
-
-## Completeness Checks
-- [ ] **CONTRACT**: If a stage's JSON shape changes, the consumer stage was updated in lockstep
-- [ ] **SIBLING**: Same unvalidated `ticks_per_beat` boundary checked in `parser.py` / other tempo-map constructors
-- [ ] **TESTS**: A regression test pins SMPTE/negative-division rejection or conversion
-- [ ] **DOC**: If behavior contradicted a `docs/*.md`, the doc was corrected
+parse_midi_to_frames passes ticks_per_beat=mid.ticks_per_beat to EnhancedTempoMap with
+no validation (parser_fast.py:24-29). SMPTE-division MIDI (division bit 15 set) -> mido
+returns ticks_per_beat NEGATIVE. calculate_time_ms (tempo_map.py:129) us_per_tick<0 ->
+negative time -> get_frame_for_tick (:144-147) negative frame indices -> events at
+negative keys, corrupt song. No error.
+Fix: check mid.ticks_per_beat > 0 after open (raise clear error or convert SMPTE to PPQ);
+assert ticks_per_beat >= 1 in TempoMap.__init__. SIBLING parser.py.

--- a/.claude/issues/94/ISSUE.md
+++ b/.claude/issues/94/ISSUE.md
@@ -1,35 +1,9 @@
 # TEMPO-02: Valid out-of-range and large-jump tempo changes silently dropped in fast parser
+Severity: HIGH · Domain: tempo · Source: AUDIT_TEMPO_2026-06-29.md
 
-Issue: #94
-
-**Severity:** HIGH · **Domain:** tempo · **Source:** AUDIT_TEMPO_2026-06-29.md
-
-## Description
-The fast parser overrides the tempo range to 40-250 BPM and swallows any `TempoValidationError` from `add_tempo_change` with a bare `continue` ("Skip invalid tempo changes silently for performance", `tracker/parser_fast.py:39-48`). Two classes of **legitimate** MIDI tempo are therefore discarded with no warning: (a) tempos below 40 BPM or above 250 BPM (largo / very fast pieces), and (b) any tempo change whose ratio to the previous tempo exceeds 3.0 (`tracker/tempo_map.py:344-353`, `max_tempo_change_ratio = 3.0`) — a normal section-boundary jump such as 200->60 BPM. When a change is dropped, the previous (or default 120 BPM) tempo persists, so **the song plays at the wrong tempo from that point on**, silently.
-
-## Location
-`tracker/parser_fast.py:39-48` (`except TempoValidationError: continue`); thresholds at `:18-23` (40-250 BPM) and ratio gate in `tracker/tempo_map.py:344-353` (default `TempoValidationConfig` `:27`).
-
-## Evidence
-With the parser's own config (40-250 BPM):
-```
-add_tempo_change(480, us(30 BPM))   -> TempoValidationError (REJECTED, then `continue`)
-add_tempo_change(960, us(280 BPM))  -> TempoValidationError (REJECTED)
-add_tempo_change(480, us(200)); add_tempo_change(960, us(60))
-                                    -> "Tempo change ratio 3.33 exceeds maximum 3.0" (REJECTED)
-```
-
-## Impact
-Wrong global/sectional tempo for any MIDI outside the narrow 40-250 BPM band or with a sharp tempo change — common in classical/film transcriptions. Silent wrong output -> HIGH. Distinct from the *note*-drop already filed in SAFE-07.
-
-## Related
-SAFE-07 (`docs/audits/AUDIT_SAFETY_2026-06-29.md:107`) covers the per-note `except Exception` at `:77` and explicitly scopes itself away from this tempo skip.
-
-## Suggested Fix
-Widen the fast-parser `TempoValidationConfig` to the full musically-valid range and relax/remove `max_tempo_change_ratio` for parsing (it is an authoring heuristic, not a hardware limit), or — at minimum — count and warn on dropped tempo changes instead of silently continuing.
-
-## Completeness Checks
-- [ ] **CONTRACT**: If a stage's JSON shape changes, the consumer stage was updated in lockstep
-- [ ] **SIBLING**: Same swallow pattern checked in `parser.py` tempo collection
-- [ ] **TESTS**: A regression test pins out-of-range / large-jump tempo retention or a warning
-- [ ] **DOC**: If behavior contradicted a `docs/*.md`, the doc was corrected
+Fast parser overrides tempo range to 40-250 BPM and swallows TempoValidationError with bare
+continue (parser_fast.py:39-48). Drops (a) tempos <40 or >250 BPM, (b) any change ratio>3.0
+(tempo_map.py:344-353 max_tempo_change_ratio=3.0). Dropped -> previous/default tempo persists
+-> wrong tempo silently. Fix: widen fast-parser TempoValidationConfig to full musical range,
+relax/remove max_tempo_change_ratio for parsing (authoring heuristic, not hw limit), or at
+minimum count+warn on drops. SIBLING parser.py.

--- a/tests/test_midi_parser_integration.py
+++ b/tests/test_midi_parser_integration.py
@@ -260,26 +260,26 @@ class TestMIDIParserIntegration(unittest.TestCase):
         expected_frame = 72
         self.assertEqual(note_event['frame'], expected_frame)
 
-    def test_invalid_tempo_handling(self):
-        """Test handling of invalid tempo changes"""
+    def test_fast_tempo_change_retained(self):
+        """Regression (TEMPO-02 / #94): a fast tempo (600 BPM) is a legitimate
+        tempo, not an error, so it must be retained rather than dropped by an
+        authoring-range cap. This test previously asserted the buggy behaviour —
+        the change was dropped and the note stayed at 120 BPM (frame 60)."""
         messages = [
-            MetaMessage('set_tempo', tempo=500000, time=0),  # 120 BPM
-            MetaMessage('set_tempo', tempo=100000, time=480),  # 600 BPM (invalid)
+            MetaMessage('set_tempo', tempo=500000, time=0),    # 120 BPM
+            MetaMessage('set_tempo', tempo=100000, time=480),  # 600 BPM (fast but valid)
             Message('note_on', note=60, velocity=64, time=480)
         ]
-        
-        midi_path = self.create_test_midi('invalid_tempo.mid', messages)
+
+        midi_path = self.create_test_midi('fast_tempo.mid', messages)
         result = parse_midi_to_frames(midi_path)
-        
-        # Get the first note event
+
         note_event = result['events']['track_0'][0]
-        
-        # Calculate expected frame:
-        # Since the second tempo change is invalid, it should be ignored
-        # 960 ticks at 120 BPM = 1000ms
-        # At 60fps, frame = 1000/16.67 ≈ 60 frames
-        expected_frame = 60
-        self.assertEqual(note_event['frame'], expected_frame)
+
+        # With the change retained: 0->480 at 120 BPM = 500ms, 480->960 at 600 BPM
+        # = 100ms, total 600ms. At 60fps, frame = 600/16.667 ≈ 36 (was 60 when the
+        # tempo was wrongly dropped).
+        self.assertEqual(note_event['frame'], 36)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_parser_fast.py
+++ b/tests/test_parser_fast.py
@@ -63,6 +63,61 @@ class TestParseMidiToFrames:
         mid.save(str(midi_path))
         return str(midi_path)
     
+    @staticmethod
+    def _us(bpm):
+        return int(round(60_000_000 / bpm))
+
+    def test_smpte_division_rejected(self):
+        # Regression (TEMPO-01 / #93): SMPTE-division MIDI makes mido report a
+        # negative ticks_per_beat, which produced negative frame indices. The
+        # parser must reject it up front instead of compiling garbage.
+        import struct
+        div = struct.pack('>h', -3200)  # division word bit 15 set => SMPTE
+        data = (b'MThd' + struct.pack('>I', 6) + struct.pack('>HH', 0, 1) + div +
+                b'MTrk' + struct.pack('>I', 4) + bytes([0x00, 0xFF, 0x2F, 0x00]))
+        path = self.temp_dir / "smpte.mid"
+        path.write_bytes(data)
+        with pytest.raises(ValueError):
+            parse_midi_to_frames(str(path))
+
+    def test_out_of_range_tempos_retained(self):
+        # Regression (TEMPO-02 / #94): a largo (30 BPM) and a fast (280 BPM)
+        # tempo are outside the old 40-250 band and were silently dropped, so the
+        # section kept the previous 120 BPM. They must now survive parsing.
+        for bpm in (30, 280):
+            tracks = [[
+                mido.MetaMessage('set_tempo', tempo=self._us(bpm), time=480),
+                mido.Message('note_on', channel=0, note=60, velocity=100, time=0),
+                mido.Message('note_off', channel=0, note=60, velocity=0, time=10),
+            ]]
+            path = self.create_test_midi(f"tempo_{bpm}.mid", tracks)
+            result = parse_midi_to_frames(path)
+            notes = [e for evs in result['events'].values()
+                     for e in evs if e['type'] == 'note_on']
+            assert notes, f"{bpm} BPM: expected a note_on"
+            assert notes[0]['tempo'] == self._us(bpm), (
+                f"{bpm} BPM tempo was dropped (got {notes[0]['tempo']}, "
+                f"expected {self._us(bpm)})")
+
+    def test_large_tempo_jump_retained(self):
+        # Regression (TEMPO-02 / #94): a normal section-boundary jump (200->60
+        # BPM, ratio 3.33) exceeded the old max_tempo_change_ratio of 3.0 and was
+        # dropped, leaving the section at 200 BPM. The ratio gate is an authoring
+        # heuristic, not a parse constraint, so the jump must be retained.
+        tracks = [[
+            mido.MetaMessage('set_tempo', tempo=self._us(200), time=480),
+            mido.MetaMessage('set_tempo', tempo=self._us(60), time=480),
+            mido.Message('note_on', channel=0, note=60, velocity=100, time=0),
+            mido.Message('note_off', channel=0, note=60, velocity=0, time=10),
+        ]]
+        path = self.create_test_midi("tempo_jump.mid", tracks)
+        result = parse_midi_to_frames(path)
+        notes = [e for evs in result['events'].values()
+                 for e in evs if e['type'] == 'note_on']
+        assert notes, "expected a note_on"
+        assert notes[0]['tempo'] == self._us(60), (
+            f"section-boundary tempo jump was dropped (got {notes[0]['tempo']})")
+
     def test_basic_midi_parsing(self):
         """Test basic MIDI file parsing"""
         midi_path = self.create_test_midi()
@@ -156,6 +211,7 @@ class TestParseMidiToFrames:
         # Create a mock MIDI file with invalid tempo
         with patch('mido.MidiFile') as mock_midi:
             mock_track = MagicMock()
+            mock_track.ticks_per_beat = 480  # valid metrical division (#93 guard)
             mock_track.tracks = [[
                 mido.MetaMessage('set_tempo', tempo=0, time=0),  # Invalid tempo
                 mido.Message('note_on', channel=0, note=60, velocity=64, time=0),
@@ -214,6 +270,7 @@ class TestParseMidiToFrames:
         """Test that problematic events are silently skipped"""
         with patch('mido.MidiFile') as mock_midi:
             mock_track = MagicMock()
+            mock_track.ticks_per_beat = 480  # valid metrical division (#93 guard)
             mock_track.tracks = [[
                 mido.Message('note_on', channel=0, note=60, velocity=64, time=0),
             ]]

--- a/tests/test_tempo_map.py
+++ b/tests/test_tempo_map.py
@@ -32,6 +32,20 @@ class TestTempoMap(unittest.TestCase):
         self.assertEqual(self.tempo_map.tempo_changes[0], (0, 500000))
         self.assertEqual(self.tempo_map.ticks_per_beat, 480)
         
+    def test_non_positive_ticks_per_beat_rejected(self):
+        # Regression (TEMPO-01 / #93): ticks_per_beat is the denominator of every
+        # tick->time conversion. mido reports it NEGATIVE for SMPTE-division MIDI;
+        # a non-positive value makes us_per_tick <= 0 and yields negative frame
+        # indices that scramble the whole song. Guard it at construction.
+        for bad in (-3200, 0, -1):
+            with self.assertRaises(ValueError):
+                TempoMap(ticks_per_beat=bad)
+            with self.assertRaises(ValueError):
+                EnhancedTempoMap(initial_tempo=500000, ticks_per_beat=bad,
+                                 optimization_strategy=None)
+        # A valid resolution still constructs fine.
+        self.assertEqual(TempoMap(ticks_per_beat=96).ticks_per_beat, 96)
+
     def test_add_tempo_change(self):
         """Test adding tempo changes"""
         self.tempo_map.add_tempo_change(480, 400000)

--- a/tracker/parser.py
+++ b/tracker/parser.py
@@ -10,11 +10,17 @@ from tracker.loop_manager import EnhancedLoopManager
 def parse_midi_to_frames(midi_path):
     mid = mido.MidiFile(midi_path)
     # Initialize with validation but NO optimization
+    # Full musically-valid tempo band with the change-ratio gate disabled: the
+    # narrow 40-250 BPM / ratio-3.0 limits are authoring heuristics, not parse
+    # constraints, and silently dropped legitimate largo/presto tempos and
+    # normal section-boundary jumps, leaving the song at the wrong tempo (#94,
+    # SIBLING of parser_fast).
     config = TempoValidationConfig(
-        min_tempo_bpm=40.0,
-        max_tempo_bpm=250.0,
+        min_tempo_bpm=1.0,
+        max_tempo_bpm=2000.0,
         min_duration_frames=2,
-        max_duration_frames=FRAME_RATE_HZ * 30  # 30 seconds
+        max_duration_frames=FRAME_RATE_HZ * 30,  # 30 seconds
+        max_tempo_change_ratio=float('inf')
     )
     tempo_map = EnhancedTempoMap(
         initial_tempo=500000,  # 120 BPM

--- a/tracker/parser_fast.py
+++ b/tracker/parser_fast.py
@@ -13,13 +13,32 @@ def parse_midi_to_frames(midi_path):
     """
     mid = mido.MidiFile(midi_path)
 
-    # Initialize tempo map with minimal validation for performance
-    # CRITICAL: Use the MIDI file's ticks_per_beat for accurate timing
+    # SMPTE-division MIDI (division word bit 15 set) makes mido report
+    # ticks_per_beat as a negative value; zero is equally degenerate. Either
+    # makes us_per_tick <= 0 and yields negative frame indices that silently
+    # scramble the whole song (#93). Reject early with an actionable message
+    # rather than compiling garbage. (TempoMap.__init__ also guards this, but a
+    # parse-stage message points the user at the real cause.)
+    if mid.ticks_per_beat is None or mid.ticks_per_beat < 1:
+        raise ValueError(
+            f"Unsupported MIDI timing division: ticks_per_beat="
+            f"{mid.ticks_per_beat!r}. This file uses SMPTE frame/sub-frame "
+            f"timing; re-export it with metrical (PPQ) timing."
+        )
+
+    # Initialize tempo map with minimal validation for performance.
+    # CRITICAL: Use the MIDI file's ticks_per_beat for accurate timing.
+    # The tempo range is widened to the full musically-valid band and the
+    # change-ratio gate is disabled: those are authoring heuristics, not parse
+    # constraints, and the narrow 40-250 BPM / ratio-3.0 limits silently dropped
+    # legitimate largo/presto tempos and normal section-boundary jumps, leaving
+    # the song at the wrong tempo (#94).
     config = TempoValidationConfig(
-        min_tempo_bpm=40.0,
-        max_tempo_bpm=250.0,
+        min_tempo_bpm=1.0,
+        max_tempo_bpm=2000.0,
         min_duration_frames=2,
-        max_duration_frames=FRAME_RATE_HZ * 300  # Allow up to 5 minutes
+        max_duration_frames=FRAME_RATE_HZ * 300,  # Allow up to 5 minutes
+        max_tempo_change_ratio=float('inf')
     )
     tempo_map = EnhancedTempoMap(
         initial_tempo=500000,  # 120 BPM
@@ -27,10 +46,11 @@ def parse_midi_to_frames(midi_path):
         validation_config=config,
         optimization_strategy=None  # Disable expensive optimization
     )
-    
+
     track_events = defaultdict(list)
 
     # First pass: collect tempo changes efficiently
+    dropped_tempo_changes = 0
     for track in mid.tracks:
         current_tick = 0
         for msg in track:
@@ -44,8 +64,15 @@ def parse_midi_to_frames(midi_path):
                         TempoChangeType.IMMEDIATE
                     )
                 except TempoValidationError:
-                    # Skip invalid tempo changes silently for performance
+                    # With the widened config this should be rare; never drop a
+                    # tempo change silently (the song would play at the wrong
+                    # tempo from here on) — count it and warn after the pass (#94).
+                    dropped_tempo_changes += 1
                     continue
+
+    if dropped_tempo_changes:
+        print(f"Warning: dropped {dropped_tempo_changes} out-of-range tempo "
+              f"change(s); affected sections will play at the preceding tempo.")
 
     # Second pass: process notes efficiently
     for i, track in enumerate(mid.tracks):
@@ -103,19 +130,22 @@ def parse_midi_to_frames_with_analysis(midi_path):
     from tracker.loop_manager import EnhancedLoopManager
     from tracker.tempo_map import EnhancedTempoMap
     
-    # Create tempo map again (could be optimized with caching)
+    # Create tempo map again (could be optimized with caching). Same widened
+    # band / disabled ratio gate as the first pass so analysis sees the real
+    # tempos rather than the narrow 40-250 BPM subset (#94).
     config = TempoValidationConfig(
-        min_tempo_bpm=40.0,
-        max_tempo_bpm=250.0,
+        min_tempo_bpm=1.0,
+        max_tempo_bpm=2000.0,
         min_duration_frames=2,
-        max_duration_frames=FRAME_RATE_HZ * 300
+        max_duration_frames=FRAME_RATE_HZ * 300,
+        max_tempo_change_ratio=float('inf')
     )
     tempo_map = EnhancedTempoMap(
         initial_tempo=500000,
         validation_config=config,
         optimization_strategy=None
     )
-    
+
     # Rebuild tempo map (this could be cached from first pass)
     mid = mido.MidiFile(midi_path)
     for track in mid.tracks:

--- a/tracker/tempo_map.py
+++ b/tracker/tempo_map.py
@@ -83,6 +83,18 @@ class TempoMap:
             initial_tempo: Microseconds per quarter note (500000 = 120 BPM)
             ticks_per_beat: MIDI ticks per quarter note
         """
+        # ticks_per_beat is the denominator of every tick->time conversion, so a
+        # non-positive value makes us_per_tick <= 0 and yields negative elapsed
+        # time / negative frame indices. mido reports a NEGATIVE ticks_per_beat
+        # for SMPTE-division MIDI headers, so guard the boundary here for every
+        # constructor rather than at each call site (#93).
+        if ticks_per_beat is None or ticks_per_beat < 1:
+            raise ValueError(
+                f"ticks_per_beat must be a positive integer (>= 1), got "
+                f"{ticks_per_beat!r}. A non-positive value typically comes from "
+                f"an SMPTE-division MIDI header (mido returns ticks_per_beat < 0 "
+                f"for SMPTE timing) and would produce negative frame indices."
+            )
         self.tempo_changes = [(0, initial_tempo)]
         self.ticks_per_beat = ticks_per_beat
         self._time_cache = {}


### PR DESCRIPTION
…, #94)

Two HIGH tempo bugs at the parse boundary:

#93 (TEMPO-01) — parse_midi_to_frames passed mid.ticks_per_beat to the tempo map unvalidated. For SMPTE-division MIDI, mido returns ticks_per_beat NEGATIVE, making us_per_tick <= 0 so calculate_time_ms goes negative and get_frame_for_tick yields negative frame indices — events land at negative keys and silently scramble the whole song. Guard the boundary in TempoMap.__init__ (raise unless ticks_per_beat >= 1, covering every constructor including parser.py) and reject SMPTE up front in parser_fast with an actionable message.

#94 (TEMPO-02) — the fast parser overrode the tempo range to 40-250 BPM and swallowed TempoValidationError with a bare `continue`, silently discarding two classes of legitimate tempo: anything outside 40-250 BPM (largo/presto) and any section-boundary jump whose ratio exceeded max_tempo_change_ratio=3.0. The dropped change left the song at the previous/default tempo from that point on. Widen the parser config to the full musical band (1-2000 BPM) and disable the ratio gate — both are authoring heuristics, not parse constraints — and count + warn on any remaining drop instead of failing silently. Applied to both parser_fast tempo maps and the parser.py sibling.

Regression tests pin SMPTE rejection, the ticks_per_beat>=1 guard, and retention of out-of-range and large-jump tempos. An integration test that asserted the old drop behaviour (600 BPM dropped -> frame 60) now verifies retention (frame 36).