### PR TITLE
fix: guard mido.MidiFile() with InvalidMIDIError and add CC65 subproc…

### DIFF
--- a/compiler/cc65_wrapper.py
+++ b/compiler/cc65_wrapper.py
@@ -59,10 +59,11 @@ class CC65Wrapper:
                 [self._ca65_path, "--version"],
                 capture_output=True,
                 text=True,
+                timeout=10,
             )
             if result.returncode != 0:
                 raise ToolchainError("ca65")
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             raise ToolchainError("ca65")
 
         try:
@@ -70,10 +71,11 @@ class CC65Wrapper:
                 [self._ld65_path, "--version"],
                 capture_output=True,
                 text=True,
+                timeout=10,
             )
             if result.returncode != 0:
                 raise ToolchainError("ld65")
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             raise ToolchainError("ld65")
 
         return True
@@ -95,16 +97,18 @@ class CC65Wrapper:
                 [self._ca65_path, "--version"],
                 capture_output=True,
                 text=True,
+                timeout=10,
             )
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             raise ToolchainError("ca65")
         try:
             ld65_result = subprocess.run(
                 [self._ld65_path, "--version"],
                 capture_output=True,
                 text=True,
+                timeout=10,
             )
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             raise ToolchainError("ld65")
 
         return (
@@ -140,12 +144,20 @@ class CC65Wrapper:
             for path in include_paths:
                 cmd.extend(["-I", str(path)])
 
-        result = subprocess.run(
-            cmd,
-            cwd=working_dir,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=working_dir,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            raise CompilationError(
+                f"ca65 timed out assembling {source_file.name}",
+                tool="ca65",
+                exit_code=-1,
+            )
 
         if result.returncode != 0:
             error_msg = result.stderr or result.stdout or "Unknown error"
@@ -195,12 +207,20 @@ class CC65Wrapper:
             for path in library_paths:
                 cmd.extend(["-L", str(path)])
 
-        result = subprocess.run(
-            cmd,
-            cwd=working_dir,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=working_dir,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            raise CompilationError(
+                "ld65 timed out linking ROM",
+                tool="ld65",
+                exit_code=-1,
+            )
 
         if result.returncode != 0:
             error_msg = result.stderr or result.stdout or "Unknown error"

--- a/tests/test_cc65_wrapper.py
+++ b/tests/test_cc65_wrapper.py
@@ -1,0 +1,129 @@
+"""
+Regression tests for compiler/cc65_wrapper.py
+
+Covers SAFE-03 (#122): subprocess.run calls must have timeout= so a hung
+ca65/ld65 process raises a typed error rather than blocking forever.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from compiler.cc65_wrapper import CC65Wrapper
+from core.exceptions import CompilationError, ToolchainError
+
+
+class TestSubprocessTimeouts:
+    """SAFE-03: TimeoutExpired must surface as a typed exception, not a hang."""
+
+    def setup_method(self):
+        self.wrapper = CC65Wrapper()
+        # Pretend the toolchain is installed so we can reach the subprocess calls.
+        self.wrapper._ca65_path = "/usr/bin/ca65"
+        self.wrapper._ld65_path = "/usr/bin/ld65"
+
+    # --- check_toolchain probes ---
+
+    def test_check_toolchain_ca65_timeout_raises_toolchain_error(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ca65", timeout=10)):
+            with pytest.raises(ToolchainError):
+                self.wrapper.check_toolchain()
+
+    def test_check_toolchain_ld65_timeout_raises_toolchain_error(self):
+        ok = MagicMock(returncode=0, stdout="ca65 2.18", stderr="")
+        # CA65 probe succeeds; LD65 probe times out.
+        with patch("subprocess.run", side_effect=[ok, subprocess.TimeoutExpired(cmd="ld65", timeout=10)]):
+            with pytest.raises(ToolchainError):
+                self.wrapper.check_toolchain()
+
+    # --- get_version probes ---
+
+    def test_get_version_ca65_timeout_raises_toolchain_error(self):
+        with patch.object(self.wrapper, "check_toolchain"):
+            with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ca65", timeout=10)):
+                with pytest.raises(ToolchainError):
+                    self.wrapper.get_version()
+
+    def test_get_version_ld65_timeout_raises_toolchain_error(self):
+        ok = MagicMock(returncode=0, stdout="ca65 2.18", stderr="")
+        with patch.object(self.wrapper, "check_toolchain"):
+            with patch("subprocess.run", side_effect=[ok, subprocess.TimeoutExpired(cmd="ld65", timeout=10)]):
+                with pytest.raises(ToolchainError):
+                    self.wrapper.get_version()
+
+    # --- assemble ---
+
+    def test_assemble_timeout_raises_compilation_error(self, tmp_path):
+        src = tmp_path / "music.asm"
+        src.write_text("; stub\n")
+        out = tmp_path / "music.o"
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ca65", timeout=120)):
+            with pytest.raises(CompilationError) as exc_info:
+                self.wrapper.assemble(src, out, working_dir=tmp_path)
+        assert exc_info.value.tool == "ca65"
+
+    def test_assemble_timeout_error_is_not_a_raw_timeout_expired(self, tmp_path):
+        src = tmp_path / "music.asm"
+        src.write_text("; stub\n")
+        out = tmp_path / "music.o"
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ca65", timeout=120)):
+            try:
+                self.wrapper.assemble(src, out, working_dir=tmp_path)
+            except CompilationError:
+                pass
+            except subprocess.TimeoutExpired:
+                pytest.fail("TimeoutExpired leaked out of assemble() — should be CompilationError")
+
+    # --- link ---
+
+    def test_link_timeout_raises_compilation_error(self, tmp_path):
+        obj = tmp_path / "music.o"
+        obj.write_bytes(b"")
+        out = tmp_path / "game.nes"
+        cfg = tmp_path / "nes.cfg"
+        cfg.write_text("; stub\n")
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ld65", timeout=120)):
+            with pytest.raises(CompilationError) as exc_info:
+                self.wrapper.link([obj], out, cfg, working_dir=tmp_path)
+        assert exc_info.value.tool == "ld65"
+
+    def test_link_timeout_error_is_not_a_raw_timeout_expired(self, tmp_path):
+        obj = tmp_path / "music.o"
+        obj.write_bytes(b"")
+        out = tmp_path / "game.nes"
+        cfg = tmp_path / "nes.cfg"
+        cfg.write_text("; stub\n")
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ld65", timeout=120)):
+            try:
+                self.wrapper.link([obj], out, cfg, working_dir=tmp_path)
+            except CompilationError:
+                pass
+            except subprocess.TimeoutExpired:
+                pytest.fail("TimeoutExpired leaked out of link() — should be CompilationError")
+
+    # --- verify timeout values are set (nonzero-exit still surfaces) ---
+
+    def test_assemble_nonzero_exit_still_raises_compilation_error(self, tmp_path):
+        src = tmp_path / "bad.asm"
+        src.write_text("; bad\n")
+        out = tmp_path / "bad.o"
+        fail_result = MagicMock(returncode=1, stderr="syntax error", stdout="")
+        with patch("subprocess.run", return_value=fail_result):
+            with pytest.raises(CompilationError):
+                self.wrapper.assemble(src, out, working_dir=tmp_path)
+
+    def test_link_nonzero_exit_still_raises_compilation_error(self, tmp_path):
+        obj = tmp_path / "bad.o"
+        obj.write_bytes(b"")
+        out = tmp_path / "game.nes"
+        cfg = tmp_path / "nes.cfg"
+        cfg.write_text("; stub\n")
+        fail_result = MagicMock(returncode=1, stderr="undefined symbol", stdout="")
+        with patch("subprocess.run", return_value=fail_result):
+            with pytest.raises(CompilationError):
+                self.wrapper.link([obj], out, cfg, working_dir=tmp_path)

--- a/tests/test_parser_fast.py
+++ b/tests/test_parser_fast.py
@@ -23,10 +23,11 @@ from unittest.mock import patch, MagicMock, mock_open
 sys.path.append(str(Path(__file__).parent.parent))
 
 from tracker.parser_fast import (
-    parse_midi_to_frames, 
+    parse_midi_to_frames,
     parse_midi_to_frames_with_analysis
 )
 from tracker.tempo_map import TempoValidationError
+from core.exceptions import InvalidMIDIError
 
 
 class TestParseMidiToFrames:
@@ -747,6 +748,47 @@ class TestEdgeCases:
         finally:
             import shutil
             shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+class TestInvalidMIDIGuard:
+    """Regression tests for SAFE-02: mido.MidiFile() guard → InvalidMIDIError (#121)."""
+
+    def setup_method(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_zero_byte_file_raises_invalid_midi_error(self):
+        zero = self.temp_dir / "empty.mid"
+        zero.write_bytes(b"")
+        with pytest.raises(InvalidMIDIError) as exc_info:
+            parse_midi_to_frames(str(zero))
+        assert str(zero) in str(exc_info.value)
+
+    def test_non_midi_file_raises_invalid_midi_error(self):
+        txt = self.temp_dir / "notmidi.mid"
+        txt.write_bytes(b"This is not a MIDI file at all.\n")
+        with pytest.raises(InvalidMIDIError):
+            parse_midi_to_frames(str(txt))
+
+    def test_truncated_midi_raises_invalid_midi_error(self):
+        # Write only the first 4 bytes of a valid MIDI header (incomplete).
+        truncated = self.temp_dir / "truncated.mid"
+        truncated.write_bytes(b"MThd")
+        with pytest.raises(InvalidMIDIError):
+            parse_midi_to_frames(str(truncated))
+
+    def test_invalid_midi_error_is_not_raw_mido_exception(self):
+        bad = self.temp_dir / "bad.mid"
+        bad.write_bytes(b"\x00" * 16)
+        try:
+            parse_midi_to_frames(str(bad))
+        except InvalidMIDIError:
+            pass  # expected
+        except Exception as e:
+            pytest.fail(f"Expected InvalidMIDIError but got {type(e).__name__}: {e}")
 
 
 if __name__ == '__main__':

--- a/tracker/parser.py
+++ b/tracker/parser.py
@@ -6,9 +6,15 @@ from tracker.tempo_map import (EnhancedTempoMap, TempoValidationConfig, TempoOpt
                                TempoChangeType, TempoValidationError)
 from tracker.pattern_detector import EnhancedPatternDetector
 from tracker.loop_manager import EnhancedLoopManager
+from core.exceptions import InvalidMIDIError
 
 def parse_midi_to_frames(midi_path):
-    mid = mido.MidiFile(midi_path)
+    try:
+        mid = mido.MidiFile(midi_path)
+    except FileNotFoundError:
+        raise  # file does not exist — not a MIDI validity issue
+    except (EOFError, OSError, ValueError) as e:
+        raise InvalidMIDIError(str(midi_path), str(e)) from e
     # Initialize with validation but NO optimization
     # Full musically-valid tempo band with the change-ratio gate disabled: the
     # narrow 40-250 BPM / ratio-3.0 limits are authoring heuristics, not parse

--- a/tracker/parser_fast.py
+++ b/tracker/parser_fast.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from constants import FRAME_MS, FRAME_RATE_HZ
 from tracker.tempo_map import (EnhancedTempoMap, TempoValidationConfig, TempoOptimizationStrategy,
                                TempoChangeType, TempoValidationError)
+from core.exceptions import InvalidMIDIError
 
 def parse_midi_to_frames(midi_path):
     """
@@ -11,7 +12,12 @@ def parse_midi_to_frames(midi_path):
     Pattern detection, loop detection, and other expensive analysis
     is moved to separate pipeline steps.
     """
-    mid = mido.MidiFile(midi_path)
+    try:
+        mid = mido.MidiFile(midi_path)
+    except FileNotFoundError:
+        raise  # file does not exist — not a MIDI validity issue
+    except (EOFError, OSError, ValueError) as e:
+        raise InvalidMIDIError(str(midi_path), str(e)) from e
 
     # SMPTE-division MIDI (division word bit 15 set) makes mido report
     # ticks_per_beat as a negative value; zero is equally degenerate. Either


### PR DESCRIPTION
…ess timeouts (#121, #122)

SAFE-02 (#121): wrap mido.MidiFile() in both parsers with try/except so that corrupt, truncated, or non-MIDI input raises InvalidMIDIError (the typed exception that existed but was never raised) rather than leaking raw mido tracebacks. FileNotFoundError is re-raised unchanged since a missing file is not a MIDI validity issue.

SAFE-03 (#122): add timeout=10 to the four CC65 --version probes and timeout=120 to the assemble/link calls in cc65_wrapper.py. subprocess.TimeoutExpired is now caught and re-raised as ToolchainError (probes) or CompilationError (build steps), preventing a hung ca65/ld65 from blocking the CLI indefinitely.